### PR TITLE
Allow underscore characters in resource key names

### DIFF
--- a/src/VSExtension/ReswPlus.Core/ResourceParser/ReswFilters.cs
+++ b/src/VSExtension/ReswPlus.Core/ResourceParser/ReswFilters.cs
@@ -26,15 +26,20 @@ namespace ReswPlus.Core.ResourceParser
             var variantedItems = from item in reswItems
                                where item.Key.Contains("_")
                                let match = regexPluralVariantItems.Match(item.Key)
-                               where match.Success
+                               where match.Success && !string.IsNullOrEmpty(match.Value)
                                let commonKey = item.Key.Substring(0, item.Key.Length - match.Length)
                                group (item: item, isVariant: match.Groups["variant"].Length > 0, isPlural: match.Groups["plural"].Length > 0)
                                by commonKey into gr
                                select gr;
             foreach (var variantedItem in variantedItems)
             {
-                if (variantedItem.Select(i => i.isPlural).Distinct().Count() != 1 ||
-                    variantedItem.Select(i => i.isVariant).Distinct().Count() != 1)
+                // all items must have the same type (pluralization, variants or both), if one of them is different, we reject all of them
+                var checkPlurals = variantedItem.Select(i => i.isPlural).Distinct();
+                var itemsAllPlurals = checkPlurals.Count() == 1 && checkPlurals.First();
+                var checkVariants = variantedItem.Select(i => i.isVariant).Distinct();
+                var itemsAllVariants = checkVariants.Count() == 1 && checkVariants.First();
+
+                if (!itemsAllPlurals && !itemsAllVariants)
                 {
                     // Ignore if items don't have the same form
                     continue;


### PR DESCRIPTION
## Fixes #21 
The underscore character `_` was until now a reserved character. This PR will allow developers to use this character in resource names that don't use pluralization or aren't variants. 