### PR TITLE
Generate markup extensions as partial

### DIFF
--- a/src/Sample/Strings/en-US/Resources.generated.cs
+++ b/src/Sample/Strings/en-US/Resources.generated.cs
@@ -346,7 +346,7 @@ namespace ReswPlusSample.Strings{
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [MarkupExtensionReturnType(ReturnType = typeof(string))]
-    public class ResourcesExtension: MarkupExtension
+    public partial class ResourcesExtension: MarkupExtension
     {
         public enum KeyEnum
         {

--- a/src/VSExtension/ReswPlus.Core/CodeGenerators/CsharpCodeGenerator.cs
+++ b/src/VSExtension/ReswPlus.Core/CodeGenerators/CsharpCodeGenerator.cs
@@ -220,7 +220,7 @@ namespace ReswPlus.Core.CodeGenerators
             builder.AppendLine("[global::System.Diagnostics.DebuggerNonUserCodeAttribute()]");
             builder.AppendLine("[global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]");
             builder.AppendLine("[MarkupExtensionReturnType(ReturnType = typeof(string))]");
-            builder.AppendLine($"public class {className}: MarkupExtension");
+            builder.AppendLine($"public partial class {className}: MarkupExtension");
             builder.AppendLine("{");
             builder.AddLevel();
             builder.AppendLine("public enum KeyEnum");

--- a/src/VSExtension/Tests/MultiResourcesAndCustomNamespace/App/Dialog/en/Dialog.generated.cs
+++ b/src/VSExtension/Tests/MultiResourcesAndCustomNamespace/App/Dialog/en/Dialog.generated.cs
@@ -27,7 +27,7 @@ namespace MultiResources.Strings {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [MarkupExtensionReturnType(ReturnType = typeof(string))]
-    public class DialogExtension: MarkupExtension
+    public partial class DialogExtension: MarkupExtension
     {
         public enum KeyEnum
         {

--- a/src/VSExtension/Tests/MultiResourcesAndCustomNamespace/App/Strings/en/Resources.generated.cs
+++ b/src/VSExtension/Tests/MultiResourcesAndCustomNamespace/App/Strings/en/Resources.generated.cs
@@ -27,7 +27,7 @@ namespace MultiResources.Strings {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [MarkupExtensionReturnType(ReturnType = typeof(string))]
-    public class ResourcesExtension: MarkupExtension
+    public partial class ResourcesExtension: MarkupExtension
     {
         public enum KeyEnum
         {

--- a/src/VSExtension/Tests/MultiResourcesAndCustomNamespace/Lib/Strings/en/Resources.generated.cs
+++ b/src/VSExtension/Tests/MultiResourcesAndCustomNamespace/Lib/Strings/en/Resources.generated.cs
@@ -27,7 +27,7 @@ namespace MultiResourcesLib.Strings{
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [MarkupExtensionReturnType(ReturnType = typeof(string))]
-    public class ResourcesExtension: MarkupExtension
+    public partial class ResourcesExtension: MarkupExtension
     {
         public enum KeyEnum
         {


### PR DESCRIPTION
CsWinRT requires types marshalled through the WinRT ABI to be marked as `partial`, so that it can generate the AOT-compatible vtable info annotations for them. The generated code from this library is currently not AOT compatible, because it generates types deriving from `MarkupExtension`, which are not `partial`. This PR fixes that.