### PR TITLE
Support Native AOT UWP projects

### DIFF
--- a/nuget/ReswPlus.targets
+++ b/nuget/ReswPlus.targets
@@ -10,12 +10,4 @@
     <PropertyGroup>
         <AdditionalFileItemNames>$(AdditionalFileItemNames);PRIResource</AdditionalFileItemNames>
     </PropertyGroup>
-    <Target Name="ReswPlusEnsurePRIResourceItems" BeforeTargets="CoreCompile">
-        <ItemGroup>
-            <_ReswPlusCandidates Include="@(None)" Condition="'%(Extension)' == '.resw'" />
-            <_ReswPlusCandidates Include="@(Content)" Condition="'%(Extension)' == '.resw'" />
-            <_ReswPlusCandidates Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.resw'" />
-            <PRIResource Include="@(_ReswPlusCandidates)" Exclude="@(PRIResource)" />
-        </ItemGroup>
-    </Target>
 </Project>

--- a/nuget/ReswPlus.targets
+++ b/nuget/ReswPlus.targets
@@ -5,8 +5,17 @@
         <CompilerVisibleProperty Include="RootNamespace" />
         <CompilerVisibleProperty Include="DefaultLanguage" />
         <CompilerVisibleProperty Include="OutputType" />
+        <CompilerVisibleProperty Include="UseUwp" />
     </ItemGroup>
     <PropertyGroup>
         <AdditionalFileItemNames>$(AdditionalFileItemNames);PRIResource</AdditionalFileItemNames>
     </PropertyGroup>
+    <Target Name="ReswPlusEnsurePRIResourceItems" BeforeTargets="CoreCompile">
+        <ItemGroup>
+            <_ReswPlusCandidates Include="@(None)" Condition="'%(Extension)' == '.resw'" />
+            <_ReswPlusCandidates Include="@(Content)" Condition="'%(Extension)' == '.resw'" />
+            <_ReswPlusCandidates Include="@(EmbeddedResource)" Condition="'%(Extension)' == '.resw'" />
+            <PRIResource Include="@(_ReswPlusCandidates)" Exclude="@(PRIResource)" />
+        </ItemGroup>
+    </Target>
 </Project>

--- a/src/ReswPlus.SourceGenerator/ReswGenerator.cs
+++ b/src/ReswPlus.SourceGenerator/ReswGenerator.cs
@@ -91,7 +91,8 @@ public partial class ReswSourceGenerator : IIncrementalGenerator
             OutputType = GetOption(options.GlobalOptions, "build_property.OutputType"),
             ProjectTypeGuids = GetOption(options.GlobalOptions, "build_property.projecttypeguids"),
             DefaultLanguage = GetOption(options.GlobalOptions, "build_property.DefaultLanguage"),
-            RootNamespace = GetOption(options.GlobalOptions, "build_property.RootNamespace")
+            RootNamespace = GetOption(options.GlobalOptions, "build_property.RootNamespace"),
+            UseUwp = GetOption(options.GlobalOptions, "build_property.UseUwp")
         });
 
         // Provider for additional files with .resw extension.
@@ -152,7 +153,9 @@ public partial class ReswSourceGenerator : IIncrementalGenerator
             }
 
             // Determine AppType based on referenced assemblies.
-            var appType = RetrieveAppType(compilation);
+            var appType = options.UseUwp?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false
+                ? AppType.UWP
+                : RetrieveAppType(compilation);
             var assemblyName = Assembly.GetExecutingAssembly().GetName().Name;
 
             switch (appType)


### PR DESCRIPTION
Native AOT UWP projects don't use `Windows.Foundation.UniversalApiContract` reference so the nuget can't recognize the UWP project. Expose and detect `UseUwp` property instead.