### PR TITLE
Update projects to .NET 10 and latest C#

### DIFF
--- a/samples/UWP/ReswPlusUWPSample/ReswPlusUWPSample.csproj
+++ b/samples/UWP/ReswPlusUWPSample/ReswPlusUWPSample.csproj
@@ -24,6 +24,7 @@
     <!-- The temporary certificate of this sample expired, and signing a package is not needed to build it -->
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>
     <Use64BitCompiler>true</Use64BitCompiler>
+    <LangVersion>latest</LangVersion>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxPackageSigningTimestampDigestAlgorithm>SHA256</AppxPackageSigningTimestampDigestAlgorithm>
     <AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
@@ -261,7 +262,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.14</Version>
+      <Version>6.2.15</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/UWP/ReswPlusUWPSampleExternalLibrary/ReswPlusUWPSampleExternalLibrary.csproj
+++ b/samples/UWP/ReswPlusUWPSampleExternalLibrary/ReswPlusUWPSampleExternalLibrary.csproj
@@ -16,6 +16,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
+    <LangVersion>latest</LangVersion>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -126,7 +127,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.14</Version>
+      <Version>6.2.15</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/WinAppSDK/ReswPlusWinAppSDKSample/ReswPlusWinAppSDKSample.csproj
+++ b/samples/WinAppSDK/ReswPlusWinAppSDKSample/ReswPlusWinAppSDKSample.csproj
@@ -2,7 +2,8 @@
   <Import Project="..\..\..\nuget\ReswPlus.targets" />
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22000.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>ReswPlusWinAppSDKSample</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -34,8 +35,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250109001-experimental2" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/samples/WinAppSDK/ReswPlusWinAppSDKSampleExternalLibrary/ReswPlusWinAppSDKSampleExternalLibrary.csproj
+++ b/samples/WinAppSDK/ReswPlusWinAppSDKSampleExternalLibrary/ReswPlusWinAppSDKSampleExternalLibrary.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\nuget\ReswPlus.targets" />
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.22000.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.22000.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>ReswPlusWinAppSDKSampleExternalLibrary</RootNamespace>
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) &gt;= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
@@ -11,8 +12,8 @@
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
-      <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250109001-experimental2" />
-      <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
+      <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
+      <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\ReswPlus.SourceGenerator\ReswPlus.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" Private="false">

--- a/src/ReswPlus.CommandLine/ReswPlusCmd.csproj
+++ b/src/ReswPlus.CommandLine/ReswPlusCmd.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <StartupObject>ReswPlusCmd.Program</StartupObject>
     <AssemblyName>ReswPlusCmd</AssemblyName>
     <Nullable>enable</Nullable>

--- a/src/ReswPlus.SourceGenerator/ReswPlus.SourceGenerator.csproj
+++ b/src/ReswPlus.SourceGenerator/ReswPlus.SourceGenerator.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
-		<LangVersion>12.0</LangVersion>
+		<LangVersion>latest</LangVersion>
 		<IsRoslynComponent>true</IsRoslynComponent>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -58,7 +58,7 @@
       <EmbeddedResource Include="Templates\Plurals\ZeroToTwoExcludedProvider.txt" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" PrivateAssets="all" />
     </ItemGroup>
     <Import Project="..\ReswPlus.Shared\ReswPlus.Shared.projitems" Label="Shared" />
 </Project>

--- a/tests/ReswPlusUnitTests/ReswPlusUnitTests.csproj
+++ b/tests/ReswPlusUnitTests/ReswPlusUnitTests.csproj
@@ -1,16 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

- upgrade the command-line tool, tests, and WinAppSDK samples to .NET 10
- use the latest C# language version across all projects
- update Roslyn to 5.6 so the source generator matches the .NET 10 compiler host
- update Windows App SDK, Windows SDK Build Tools, UWP, and test dependencies

## Why

Keeping the generator and consuming projects on the same compiler generation prevents `CS9057` analyzer-loading failures while moving the repository to the current .NET and C# toolchain.

## Validation

- rebuilt the complete solution in Debug x64 with Visual Studio MSBuild
- passed all 308 unit tests on .NET 10