### PR TITLE
Test the generator the way the compiler runs it

### DIFF
--- a/tests/ReswPlusUnitTests/GeneratorEndToEnd.cs
+++ b/tests/ReswPlusUnitTests/GeneratorEndToEnd.cs
@@ -1,0 +1,399 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace ReswPlusUnitTests;
+
+/// <summary>
+/// Runs the generator the way the compiler runs it, and compiles what comes out.
+/// </summary>
+/// <remarks>
+/// These tests are the only ones that cover <see cref="ReswPlus.SourceGenerator.ReswSourceGenerator"/> itself:
+/// the MSBuild properties it reads, the kind of app it infers from the references of the compilation, the
+/// namespace it derives from the folder of a resource, the language it picks to generate from, and the shared
+/// support sources it has to emit exactly once per project. They also assert that the emitted code builds, at
+/// the language version a UWP project uses by default, which is the guarantee a source generator lives or dies
+/// by.
+/// </remarks>
+public class GeneratorEndToEnd
+{
+    /// <summary>
+    /// A resource file exercising every kind of member the generator emits.
+    /// </summary>
+    private static string EveryFeature => ReswTestHelpers.CreateResw(
+        ("Plain", "A plain string", null),
+        ("Formatted", "Hello {0}, you are {1}", "#Format[String name, Int age]"),
+        ("Named", "Hello {0}", "#Format[String userName]"),
+        ("Literal", "{0} - {1}", "#Format[String name, \"a literal\"]"),
+        ("WithMacro", "Today is {0}", "#Format[DATE]"),
+        ("WithReference", "{0} and {1}", "#Format[String name, Plain]"),
+        ("Items_One", "{0} item", "#Format[Plural itemCount]"),
+        ("Items_Other", "{0} items", "#Format[Plural itemCount]"),
+        ("Items_None", "no item", null),
+        ("Message_Variant1", "She wrote", "#Format[Variant]"),
+        ("Message_Variant2", "He wrote", "#Format[Variant]"));
+
+    [Theory]
+    [InlineData(ReswPlus.SourceGenerator.AppType.WindowsAppSDK)]
+    [InlineData(ReswPlus.SourceGenerator.AppType.UWP)]
+    public void TheGeneratedCodeCompiles(ReswPlus.SourceGenerator.AppType appType)
+    {
+        var run = ReswGeneratorHarness.Run([ReswGeneratorHarness.File("en-US", EveryFeature)], appType);
+
+        Assert.Empty(run.Diagnostics.Where(diagnostic => diagnostic.Severity >= DiagnosticSeverity.Warning));
+        run.AssertCompiles();
+    }
+
+    [Fact]
+    public void TheGeneratedCodeCompilesWhenThePluralLanguageComesFromTheApplicationLanguages()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", EveryFeature)],
+            useApplicationLanguages: true);
+
+        run.AssertCompiles();
+    }
+
+    [Theory]
+    [InlineData(ReswPlus.SourceGenerator.AppType.WindowsAppSDK, false)]
+    [InlineData(ReswPlus.SourceGenerator.AppType.WindowsAppSDK, true)]
+    [InlineData(ReswPlus.SourceGenerator.AppType.UWP, false)]
+    [InlineData(ReswPlus.SourceGenerator.AppType.UWP, true)]
+    public void TheGeneratedCodeCompilesForEveryCombinationOfAppTypeAndLanguageSource(
+        ReswPlus.SourceGenerator.AppType appType,
+        bool useApplicationLanguages)
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", EveryFeature)],
+            appType,
+            useApplicationLanguages: useApplicationLanguages);
+
+        run.AssertCompiles();
+    }
+
+    [Fact]
+    public void AWindowsAppSdkProjectBindsToTheWindowsAppSdkFramework()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)))],
+            ReswPlus.SourceGenerator.AppType.WindowsAppSDK);
+
+        Assert.Contains("using Microsoft.UI.Xaml.Markup;", run.Source("Resources.resw"));
+        Assert.Contains("Microsoft.Windows.ApplicationModel.Resources", run.Source("ResourceStringProvider"));
+    }
+
+    [Fact]
+    public void AUwpProjectBindsToTheUwpFramework()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)))],
+            ReswPlus.SourceGenerator.AppType.UWP);
+
+        Assert.Contains("using Windows.UI.Xaml.Markup;", run.Source("Resources.resw"));
+        Assert.Contains("GetForViewIndependentUse", run.Source("ResourceStringProvider"));
+    }
+
+    [Fact]
+    public void AProjectThatIsNeitherUwpNorWindowsAppSdkIsReported()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)))],
+            ReswPlus.SourceGenerator.AppType.Unknown);
+
+        Assert.Contains("RESWP0005", run.DiagnosticIds);
+        Assert.Empty(run.Sources);
+    }
+
+    [Fact]
+    public void AProjectWithoutARootNamespaceIsReported()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)))],
+            rootNamespace: null);
+
+        Assert.Contains("RESWP0002", run.DiagnosticIds);
+    }
+
+    [Fact]
+    public void AProjectWithoutARootPathIsReported()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)))],
+            projectDir: null);
+
+        Assert.Contains("RESWP0003", run.DiagnosticIds);
+    }
+
+    [Fact]
+    public void TheRootPathFallsBackToTheProjectFile()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)))],
+            projectDir: null,
+            msBuildProjectFullPath: $@"{ReswGeneratorHarness.ProjectDir}TestProject.csproj");
+
+        Assert.DoesNotContain("RESWP0003", run.DiagnosticIds);
+        Assert.Contains("namespace TestProject.Strings", run.Source("Resources.resw"));
+    }
+
+    [Fact]
+    public void AProjectThatDeclaresNeitherAnOutputTypeNorProjectTypeGuidsIsReported()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)))],
+            outputType: null);
+
+        Assert.Contains("RESWP0004", run.DiagnosticIds);
+    }
+
+    [Fact]
+    public void ALegacyProjectIsRecognizedAsALibraryThroughItsProjectTypeGuids()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)))],
+            outputType: null,
+            projectTypeGuids: "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}",
+            assemblyName: "MyLibrary");
+
+        Assert.DoesNotContain("RESWP0004", run.DiagnosticIds);
+
+        // A library addresses its resources through the name of the assembly holding them.
+        Assert.Contains("\"MyLibrary/Resources\"", run.Source("Resources.resw"));
+    }
+
+    [Theory]
+    [InlineData("Library", "\"MyLibrary/Resources\"")]
+    [InlineData("WinExe", "\"Resources\"")]
+    [InlineData("Exe", "\"Resources\"")]
+    public void TheResourceMapOfALibraryIsQualifiedWithItsAssemblyName(string outputType, string expectedResourceMap)
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)))],
+            outputType: outputType,
+            assemblyName: "MyLibrary");
+
+        Assert.Contains(expectedResourceMap, run.Source("Resources.resw"));
+        run.AssertCompiles();
+    }
+
+    [Fact]
+    public void TheNamespaceOfTheGeneratedClassFollowsTheFolderOfTheResource()
+    {
+        var run = ReswGeneratorHarness.Run(
+        [
+            ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)), folder: @"Assets\Text"),
+        ]);
+
+        Assert.Contains("namespace TestProject.Assets.Text", run.Source("Resources.resw"));
+        run.AssertCompiles();
+    }
+
+    [Fact]
+    public void TheDefaultLanguageOfTheProjectPicksTheResourceTheCodeIsGeneratedFrom()
+    {
+        var english = ReswTestHelpers.CreateResw(("OnlyInEnglish", "English", null));
+        var french = ReswTestHelpers.CreateResw(("OnlyInFrench", "Français", null));
+
+        var run = ReswGeneratorHarness.Run(
+        [
+            ReswGeneratorHarness.File("en-US", english),
+            ReswGeneratorHarness.File("fr-FR", french),
+        ],
+        defaultLanguage: "fr-FR");
+
+        var generated = run.Source("Resources.resw");
+
+        Assert.Contains("OnlyInFrench", generated);
+        Assert.DoesNotContain("OnlyInEnglish", generated);
+        run.AssertCompiles();
+    }
+
+    [Fact]
+    public void OnlyOneClassIsGeneratedForAResourceTranslatedInSeveralLanguages()
+    {
+        var run = ReswGeneratorHarness.Run(
+        [
+            ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null))),
+            ReswGeneratorHarness.File("fr-FR", ReswTestHelpers.CreateResw(("Plain", "Une chaîne", null))),
+            ReswGeneratorHarness.File("de-DE", ReswTestHelpers.CreateResw(("Plain", "Eine Zeichenfolge", null))),
+        ]);
+
+        Assert.Single(run.Sources.Keys, name => name.Contains("Resources.resw"));
+        run.AssertCompiles();
+    }
+
+    [Fact]
+    public void AProjectHoldingSeveralResourcesGeneratesAClassForEachOfThem()
+    {
+        var run = ReswGeneratorHarness.Run(
+        [
+            ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("FromFirst", "First", null)), baseName: "Resources"),
+            ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("FromSecond", "Second", null)), baseName: "Errors"),
+        ]);
+
+        Assert.Contains("FromFirst", run.Source("Resources.resw"));
+        Assert.Contains("FromSecond", run.Source("Errors.resw"));
+        run.AssertCompiles();
+    }
+
+    [Fact]
+    public void TwoResourcesOfTheSameNameInDifferentFoldersDoNotCollide()
+    {
+        var run = ReswGeneratorHarness.Run(
+        [
+            ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("FromAssets", "Assets", null)), folder: "Assets"),
+            ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("FromStrings", "Strings", null)), folder: "Strings"),
+        ]);
+
+        Assert.Equal(2, run.Sources.Keys.Count(name => name.Contains("Resources.resw")));
+        Assert.Contains("namespace TestProject.Assets", run.Source("TestProject.Assets.en-US.Resources.resw"));
+        Assert.Contains("namespace TestProject.Strings", run.Source("TestProject.Strings.en-US.Resources.resw"));
+        run.AssertCompiles();
+    }
+
+    /// <summary>
+    /// Covers the regression the generator guards against with its set of emitted hint names: the support
+    /// sources are shared by every resource of a project, and emitting one of them twice used to make the
+    /// generator produce nothing at all.
+    /// </summary>
+    [Fact]
+    public void TheSharedSupportSourcesAreEmittedOnceForAProjectHoldingSeveralResources()
+    {
+        var first = ReswTestHelpers.CreateResw(
+            ("WithMacro", "Today is {0}", "#Format[DATE]"),
+            ("Items_One", "{0} item", "#Format[Plural itemCount]"),
+            ("Items_Other", "{0} items", "#Format[Plural itemCount]"));
+
+        var second = ReswTestHelpers.CreateResw(
+            ("AlsoWithMacro", "The time is {0}", "#Format[TIME]"),
+            ("Failures_One", "{0} error", "#Format[Plural errorCount]"),
+            ("Failures_Other", "{0} errors", "#Format[Plural errorCount]"));
+
+        var run = ReswGeneratorHarness.Run(
+        [
+            ReswGeneratorHarness.File("en-US", first, baseName: "Resources"),
+            ReswGeneratorHarness.File("en-US", second, baseName: "Errors"),
+        ]);
+
+        Assert.Single(run.Sources.Keys, name => name.StartsWith("Macros", System.StringComparison.Ordinal));
+        Assert.Single(run.Sources.Keys, name => name.StartsWith("ResourceLoaderExtension", System.StringComparison.Ordinal));
+        Assert.Single(run.Sources.Keys, name => name.StartsWith("IPluralProvider", System.StringComparison.Ordinal));
+        run.AssertCompiles();
+    }
+
+    [Fact]
+    public void ThePluralSupportIsOnlyEmittedForAResourceThatUsesIt()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)))]);
+
+        Assert.DoesNotContain(run.Sources.Keys, name => name.StartsWith("ResourceLoaderExtension", System.StringComparison.Ordinal));
+        Assert.DoesNotContain(run.Sources.Keys, name => name.StartsWith("Macros", System.StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ThePluralProviderOfEveryLanguageOfTheProjectIsEmitted()
+    {
+        var plural = ReswTestHelpers.CreateResw(
+            ("Items_One", "{0} item", "#Format[Plural itemCount]"),
+            ("Items_Other", "{0} items", "#Format[Plural itemCount]"));
+
+        var run = ReswGeneratorHarness.Run(
+        [
+            ReswGeneratorHarness.File("en-US", plural),
+            ReswGeneratorHarness.File("ru-RU", plural),
+            ReswGeneratorHarness.File("cy-GB", plural),
+        ]);
+
+        var selector = run.Source("ResourceLoaderExtension");
+
+        Assert.Contains("case \"en\":", selector);
+        Assert.Contains("case \"ru\":", selector);
+        Assert.Contains("case \"cy\":", selector);
+        Assert.Contains(run.Sources.Keys, name => name.StartsWith("SlavicProvider", System.StringComparison.Ordinal));
+        Assert.Contains(run.Sources.Keys, name => name.StartsWith("WelshProvider", System.StringComparison.Ordinal));
+        run.AssertCompiles();
+    }
+
+    [Fact]
+    public void ALanguageWithoutPluralRulesIsReportedAgainstOneOfItsFiles()
+    {
+        var plural = ReswTestHelpers.CreateResw(
+            ("Items_One", "{0} item", "#Format[Plural itemCount]"),
+            ("Items_Other", "{0} items", "#Format[Plural itemCount]"));
+
+        var run = ReswGeneratorHarness.Run(
+        [
+            ReswGeneratorHarness.File("en-US", plural),
+            ReswGeneratorHarness.File("zz-ZZ", plural),
+        ]);
+
+        var reported = Assert.Single(run.Diagnostics, diagnostic => diagnostic.Id == "RESWP0011");
+
+        Assert.Contains("zz", reported.GetMessage());
+        Assert.Contains(@"zz-ZZ\Resources.resw", reported.Location.GetLineSpan().Path);
+        run.AssertCompiles();
+    }
+
+    [Fact]
+    public void AProjectWithoutAnyResourceGeneratesNothingAndReportsNothing()
+    {
+        var run = ReswGeneratorHarness.Run([]);
+
+        Assert.Empty(run.Diagnostics.Where(diagnostic => diagnostic.Severity >= DiagnosticSeverity.Warning));
+        Assert.DoesNotContain(run.Sources.Keys, name => name.Contains(".resw"));
+    }
+
+    [Fact]
+    public void TheFilesTheGeneratorDoesNotOwnAreIgnored()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)))],
+            additionalFiles:
+            [
+                new ReswFile($@"{ReswGeneratorHarness.ProjectDir}readme.txt", "not a resource"),
+                new ReswFile($@"{ReswGeneratorHarness.ProjectDir}Strings\en-US\Other.json", "{}"),
+            ]);
+
+        Assert.Single(run.Sources.Keys, name => name.Contains(".resw"));
+        run.AssertCompiles();
+    }
+
+    [Fact]
+    public void TheExtensionOfAResourceIsMatchedWhateverItsCase()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [new ReswFile($@"{ReswGeneratorHarness.ProjectDir}Strings\en-US\Resources.RESW", ReswTestHelpers.CreateResw(("Plain", "A plain string", null)))]);
+
+        Assert.Contains(run.Sources.Keys, name => name.Contains("Resources.RESW"));
+    }
+
+    [Fact]
+    public void RunningTheGeneratorTwiceOverTheSameProjectProducesTheSameSources()
+    {
+        var files = new[] { ReswGeneratorHarness.File("en-US", EveryFeature) };
+
+        var first = ReswGeneratorHarness.Run(files);
+        var second = ReswGeneratorHarness.Run(files);
+
+        Assert.Equal(
+            first.Sources.OrderBy(source => source.Key, System.StringComparer.Ordinal),
+            second.Sources.OrderBy(source => source.Key, System.StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void EditingAResourceIsReflectedInTheGeneratedSources()
+    {
+        var run = ReswGeneratorHarness.Run(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("Before", "Before", null)))]);
+
+        Assert.Contains("Before", run.Source("Resources.resw"));
+
+        var edited = run.RunAgain(
+            [ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(("After", "After", null)))]);
+
+        Assert.Contains("After", edited.Source("Resources.resw"));
+        Assert.DoesNotContain("Before", edited.Source("Resources.resw"));
+        edited.AssertCompiles();
+    }
+}

--- a/tests/ReswPlusUnitTests/GeneratorHarness.cs
+++ b/tests/ReswPlusUnitTests/GeneratorHarness.cs
@@ -1,0 +1,520 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using ReswPlus.SourceGenerator;
+using Xunit;
+
+namespace ReswPlusUnitTests;
+
+/// <summary>
+/// Runs <see cref="ReswSourceGenerator"/> the way the compiler runs it, over an in-memory project.
+/// </summary>
+/// <remarks>
+/// The rest of the suite reaches into <see cref="ReswPlus.SourceGenerator.ClassGenerators.ReswClassGenerator"/>
+/// directly, which leaves everything the generator itself does untested: reading the MSBuild properties,
+/// deciding the kind of app from the references of the compilation, grouping the files of a resource by
+/// language, naming the generated types after the folder they sit in, and emitting the shared support sources
+/// exactly once for a project holding several <c>.resw</c> files. This harness drives the real
+/// <see cref="Microsoft.CodeAnalysis.IIncrementalGenerator"/> through a <see cref="CSharpGeneratorDriver"/> so
+/// that those are covered, and it compiles what comes out, which is the only way to catch the failure a
+/// generator is most prone to: emitting source that doesn't build in the consumer's project.
+/// </remarks>
+internal static class ReswGeneratorHarness
+{
+    /// <summary>
+    /// The directory the generated project is rooted at.
+    /// </summary>
+    public const string ProjectDir = @"C:\Project\";
+
+    /// <summary>
+    /// Builds a <c>.resw</c> file sitting in the language folder of a resource.
+    /// </summary>
+    /// <param name="language">The name of the language folder, such as <c>en-US</c>.</param>
+    /// <param name="content">The content of the file.</param>
+    /// <param name="baseName">The name of the resource, without extension.</param>
+    /// <param name="folder">The folder of the project holding the resource.</param>
+    /// <returns>The file to hand to <see cref="Run"/>.</returns>
+    public static ReswFile File(string language, string content, string baseName = "Resources", string folder = "Strings")
+    {
+        return new ReswFile($@"{ProjectDir}{folder}\{language}\{baseName}.resw", content);
+    }
+
+    /// <summary>
+    /// Runs the generator over a project.
+    /// </summary>
+    /// <param name="files">The <c>.resw</c> files of the project.</param>
+    /// <param name="appType">The kind of app to make the references of the compilation describe.</param>
+    /// <param name="rootNamespace">The <c>RootNamespace</c> of the project, or <see langword="null"/> to leave it undeclared.</param>
+    /// <param name="outputType">The <c>OutputType</c> of the project, or <see langword="null"/> to leave it undeclared.</param>
+    /// <param name="projectDir">The <c>ProjectDir</c> of the project, or <see langword="null"/> to leave it undeclared.</param>
+    /// <param name="msBuildProjectFullPath">The <c>MSBuildProjectFullPath</c> of the project, which is the fallback for <paramref name="projectDir"/>.</param>
+    /// <param name="projectTypeGuids">The <c>ProjectTypeGuids</c> of the project, which is how a legacy project declares that it is a library.</param>
+    /// <param name="defaultLanguage">The <c>DefaultLanguage</c> of the project, which picks the language the code is generated from.</param>
+    /// <param name="useApplicationLanguages">The <c>ReswPlusUseApplicationLanguages</c> of the project, or <see langword="null"/> to leave it undeclared.</param>
+    /// <param name="assemblyName">The name of the assembly being compiled.</param>
+    /// <param name="additionalFiles">Files to pass to the compiler on top of <paramref name="files"/>, to cover what the generator does with the ones it doesn't own.</param>
+    /// <returns>The result of the run.</returns>
+    public static ReswGeneratorRun Run(
+        IEnumerable<ReswFile> files,
+        AppType appType = AppType.WindowsAppSDK,
+        string? rootNamespace = "TestProject",
+        string? outputType = "Library",
+        string? projectDir = ProjectDir,
+        string? msBuildProjectFullPath = null,
+        string? projectTypeGuids = null,
+        string? defaultLanguage = null,
+        bool? useApplicationLanguages = null,
+        string assemblyName = "TestProject",
+        IEnumerable<ReswFile>? additionalFiles = null)
+    {
+        var texts = files
+            .Concat(additionalFiles ?? [])
+            .Select(file => (AdditionalText)new InMemoryAdditionalText(file.Path, file.Content))
+            .ToImmutableArray();
+
+        // The compiler keys the options of a project case insensitively, and the generator reads some of them
+        // in a different case than MSBuild writes them, so the harness has to key them the same way.
+        var options = new Dictionary<string, string>(AnalyzerConfigOptions.KeyComparer);
+
+        Declare("build_property.ProjectDir", projectDir);
+        Declare("build_property.MSBuildProjectFullPath", msBuildProjectFullPath);
+        Declare("build_property.OutputType", outputType);
+        Declare("build_property.ProjectTypeGuids", projectTypeGuids);
+        Declare("build_property.DefaultLanguage", defaultLanguage);
+        Declare("build_property.RootNamespace", rootNamespace);
+        Declare("build_property.ReswPlusUseApplicationLanguages", useApplicationLanguages?.ToString().ToLowerInvariant());
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            syntaxTrees: null,
+            PlatformStubs.ReferencesFor(appType),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var driver = CSharpGeneratorDriver.Create(
+            [new ReswSourceGenerator().AsSourceGenerator()],
+            texts,
+            ParseOptions,
+            new TestAnalyzerConfigOptionsProvider(options),
+            new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true));
+
+        return ReswGeneratorRun.From(driver, compilation);
+
+        void Declare(string key, string? value)
+        {
+            if (value is not null)
+            {
+                options[key] = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The options the generated sources are parsed with.
+    /// </summary>
+    /// <remarks>
+    /// The language version is the one a UWP project gets by default, which is the floor the generated code has
+    /// to stay under, and the documentation mode is the one that reports the malformed documentation comments a
+    /// resource value can produce.
+    /// </remarks>
+    private static readonly CSharpParseOptions ParseOptions =
+        new(LanguageVersion.CSharp7_3, DocumentationMode.Diagnose);
+}
+
+/// <summary>
+/// A <c>.resw</c> file of a generated project.
+/// </summary>
+/// <param name="Path">The full path of the file.</param>
+/// <param name="Content">The content of the file.</param>
+internal sealed record ReswFile(string Path, string Content);
+
+/// <summary>
+/// The outcome of a run of the generator.
+/// </summary>
+internal sealed class ReswGeneratorRun
+{
+    private readonly GeneratorDriver _driver;
+    private readonly Compilation _inputCompilation;
+
+    private ReswGeneratorRun(GeneratorDriver driver, Compilation inputCompilation, Compilation outputCompilation, ImmutableArray<Diagnostic> diagnostics)
+    {
+        _driver = driver;
+        _inputCompilation = inputCompilation;
+        OutputCompilation = outputCompilation;
+        Diagnostics = diagnostics;
+    }
+
+    /// <summary>
+    /// The diagnostics the generator reported.
+    /// </summary>
+    public ImmutableArray<Diagnostic> Diagnostics { get; }
+
+    /// <summary>
+    /// The compilation the generated sources were added to.
+    /// </summary>
+    public Compilation OutputCompilation { get; }
+
+    /// <summary>
+    /// The sources the generator emitted, keyed by hint name.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Sources =>
+        _driver.GetRunResult().Results.Single().GeneratedSources.ToDictionary(
+            source => source.HintName,
+            source => source.SourceText.ToString());
+
+    /// <summary>
+    /// The identifiers of the diagnostics the generator reported.
+    /// </summary>
+    public IReadOnlyList<string> DiagnosticIds => [.. Diagnostics.Select(diagnostic => diagnostic.Id)];
+
+    internal static ReswGeneratorRun From(GeneratorDriver driver, Compilation compilation)
+    {
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+
+        return new ReswGeneratorRun(driver, compilation, outputCompilation, diagnostics);
+    }
+
+    /// <summary>
+    /// Runs the generator again over a new set of files, reusing the state of the previous run.
+    /// </summary>
+    /// <param name="files">The files of the project for this run.</param>
+    /// <returns>The result of the second run, which remembers what the first one computed.</returns>
+    /// <remarks>
+    /// This is how the compiler behaves while a project is edited, and it is the only way to observe what the
+    /// generator recomputes and what it reuses.
+    /// </remarks>
+    public ReswGeneratorRun RunAgain(IEnumerable<ReswFile> files)
+    {
+        var texts = files
+            .Select(file => (AdditionalText)new InMemoryAdditionalText(file.Path, file.Content))
+            .ToImmutableArray();
+
+        return From(_driver.ReplaceAdditionalTexts(texts), _inputCompilation);
+    }
+
+    /// <summary>
+    /// Returns the source emitted under the hint name holding the given text.
+    /// </summary>
+    /// <param name="hintNamePart">A part of the hint name of the wanted source.</param>
+    /// <returns>The content of the matching source.</returns>
+    public string Source(string hintNamePart)
+    {
+        var sources = Sources;
+        var matches = sources.Keys.Where(name => name.Contains(hintNamePart, StringComparison.Ordinal)).ToArray();
+
+        Assert.True(
+            matches.Length == 1,
+            $"Expected exactly one generated source whose hint name holds '{hintNamePart}', found {matches.Length}. " +
+            $"The generator emitted: {string.Join(", ", sources.Keys.OrderBy(name => name, StringComparer.Ordinal))}.");
+
+        return sources[matches[0]];
+    }
+
+    /// <summary>
+    /// Asserts that the generated sources compile, without an error and without a warning.
+    /// </summary>
+    /// <remarks>
+    /// A generator that emits source that doesn't build breaks the build of its consumer with an error that
+    /// points at generated code rather than at the resource that caused it, so what comes out is compiled here
+    /// rather than only parsed. Warnings count too: the generated code lands in projects that build with
+    /// warnings as errors.
+    /// </remarks>
+    public void AssertCompiles()
+    {
+        using var peStream = new MemoryStream();
+
+        var result = OutputCompilation.Emit(peStream);
+
+        var problems = result.Diagnostics
+            .Where(diagnostic => diagnostic.Severity is DiagnosticSeverity.Error or DiagnosticSeverity.Warning)
+            .ToArray();
+
+        Assert.True(
+            problems.Length == 0,
+            $"The generated sources do not compile cleanly:{Environment.NewLine}" +
+            string.Join(Environment.NewLine, problems.Select(Describe)));
+
+        string Describe(Diagnostic diagnostic)
+        {
+            var tree = diagnostic.Location.SourceTree;
+            var source = tree is null ? "" : $" [{tree.FilePath}]";
+
+            return $"  {diagnostic.Severity}: {diagnostic}{source}";
+        }
+    }
+
+    /// <summary>
+    /// Returns the reasons a step of the pipeline was run for, keyed by the name the step is tracked under.
+    /// </summary>
+    /// <remarks>
+    /// A step whose inputs didn't change is reported as <see cref="IncrementalStepRunReason.Cached"/> or
+    /// <see cref="IncrementalStepRunReason.Unchanged"/>, which is what tells a test that the generator reused
+    /// what it had rather than recomputing it.
+    /// </remarks>
+    public IReadOnlyDictionary<string, IReadOnlyList<IncrementalStepRunReason>> TrackedSteps()
+    {
+        return _driver.GetRunResult().Results.Single().TrackedSteps.ToDictionary(
+            step => step.Key,
+            step => (IReadOnlyList<IncrementalStepRunReason>)
+                [.. step.Value.SelectMany(run => run.Outputs).Select(output => output.Reason)]);
+    }
+
+    /// <summary>
+    /// Asserts that a tracked step of the pipeline reused everything it had computed before.
+    /// </summary>
+    /// <param name="stepName">The name the step is tracked under.</param>
+    public void AssertReused(string stepName)
+    {
+        var steps = TrackedSteps();
+
+        Assert.True(
+            steps.ContainsKey(stepName),
+            $"No step is tracked under '{stepName}'. The pipeline tracks: " +
+            $"{string.Join(", ", steps.Keys.OrderBy(name => name, StringComparer.Ordinal))}.");
+
+        var recomputed = steps[stepName]
+            .Where(reason => reason is not (IncrementalStepRunReason.Cached or IncrementalStepRunReason.Unchanged))
+            .ToArray();
+
+        Assert.True(
+            recomputed.Length == 0,
+            $"The step '{stepName}' was expected to be reused, but {recomputed.Length} of its outputs were " +
+            $"recomputed: {string.Join(", ", recomputed)}.");
+    }
+}
+
+/// <summary>
+/// An <see cref="AdditionalText"/> whose content is held in memory.
+/// </summary>
+/// <param name="path">The path to report for the file.</param>
+/// <param name="content">The content of the file.</param>
+internal sealed class InMemoryAdditionalText(string path, string content) : AdditionalText
+{
+    private readonly SourceText _text = SourceText.From(content, Encoding.UTF8);
+
+    /// <inheritdoc/>
+    public override string Path { get; } = path;
+
+    /// <inheritdoc/>
+    public override SourceText GetText(CancellationToken cancellationToken = default)
+    {
+        return _text;
+    }
+}
+
+/// <summary>
+/// The MSBuild properties of a generated project, as the compiler exposes them.
+/// </summary>
+/// <param name="globalOptions">The properties of the project.</param>
+internal sealed class TestAnalyzerConfigOptionsProvider(IReadOnlyDictionary<string, string> globalOptions)
+    : AnalyzerConfigOptionsProvider
+{
+    /// <inheritdoc/>
+    public override AnalyzerConfigOptions GlobalOptions { get; } = new TestAnalyzerConfigOptions(globalOptions);
+
+    /// <inheritdoc/>
+    public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => TestAnalyzerConfigOptions.Empty;
+
+    /// <inheritdoc/>
+    public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => TestAnalyzerConfigOptions.Empty;
+
+    private sealed class TestAnalyzerConfigOptions(IReadOnlyDictionary<string, string> options) : AnalyzerConfigOptions
+    {
+        public static readonly TestAnalyzerConfigOptions Empty = new(new Dictionary<string, string>());
+
+        public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
+        {
+            return options.TryGetValue(key, out value);
+        }
+    }
+}
+
+/// <summary>
+/// The references that make a compilation look like the kind of app the generator supports.
+/// </summary>
+/// <remarks>
+/// The generator decides between UWP and the Windows App SDK by looking for a reference whose name holds
+/// <c>Windows.Foundation.UniversalApiContract</c> or <c>Microsoft.WindowsAppSdk</c>, and the code it emits
+/// derives from the XAML markup extension of the matching framework and talks to its resource loader. Both are
+/// stubbed here rather than pulled in as real packages: the real ones are a Windows-only, version-pinned
+/// dependency, while their shape is small and is exactly what the generated code needs to compile against.
+/// </remarks>
+internal static class PlatformStubs
+{
+    /// <summary>
+    /// The types the code generated for the Windows App SDK binds to.
+    /// </summary>
+    private const string WindowsAppSdkStub = """
+        namespace Microsoft.UI.Xaml.Markup
+        {
+            public abstract class MarkupExtension
+            {
+                protected MarkupExtension() { }
+                protected virtual object ProvideValue() { return null; }
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+            public sealed class MarkupExtensionReturnTypeAttribute : System.Attribute
+            {
+                public System.Type ReturnType { get; set; }
+            }
+        }
+
+        namespace Microsoft.UI.Xaml.Data
+        {
+            public interface IValueConverter
+            {
+                object Convert(object value, System.Type targetType, object parameter, string language);
+                object ConvertBack(object value, System.Type targetType, object parameter, string language);
+            }
+        }
+
+        namespace Microsoft.Windows.ApplicationModel.Resources
+        {
+            public sealed class ResourceLoader
+            {
+                public ResourceLoader(string fileName, string resourceMap) { }
+                public static string GetDefaultResourceFilePath() { return ""; }
+                public string GetString(string resourceId) { return ""; }
+            }
+        }
+
+        namespace Microsoft.Windows.Globalization
+        {
+            public static class ApplicationLanguages
+            {
+                public static string PrimaryLanguageOverride { get; set; }
+            }
+        }
+
+        namespace Windows.Globalization
+        {
+            public static class ApplicationLanguages
+            {
+                public static System.Collections.Generic.IReadOnlyList<string> Languages { get; set; }
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The types the code generated for UWP binds to.
+    /// </summary>
+    private const string UwpStub = """
+        namespace Windows.UI.Xaml.Markup
+        {
+            public abstract class MarkupExtension
+            {
+                protected MarkupExtension() { }
+                protected virtual object ProvideValue() { return null; }
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+            public sealed class MarkupExtensionReturnTypeAttribute : System.Attribute
+            {
+                public System.Type ReturnType { get; set; }
+            }
+        }
+
+        namespace Windows.UI.Xaml.Data
+        {
+            public interface IValueConverter
+            {
+                object Convert(object value, System.Type targetType, object parameter, string language);
+                object ConvertBack(object value, System.Type targetType, object parameter, string language);
+            }
+        }
+
+        namespace Windows.ApplicationModel.Resources
+        {
+            public sealed class ResourceLoader
+            {
+                public static ResourceLoader GetForViewIndependentUse(string name) { return null; }
+                public string GetString(string resourceId) { return ""; }
+            }
+        }
+
+        namespace Windows.Globalization
+        {
+            public static class ApplicationLanguages
+            {
+                public static System.Collections.Generic.IReadOnlyList<string> Languages { get; set; }
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The assemblies of the running runtime, which is what the generated code takes its BCL types from.
+    /// </summary>
+    /// <remarks>
+    /// The Windows projection is left out on purpose: it declares some of the types stubbed here, and having
+    /// both would make the generated code compile against whichever one wins rather than against a known shape.
+    /// </remarks>
+    private static readonly Lazy<ImmutableArray<MetadataReference>> RuntimeReferences = new(() =>
+        [.. ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Where(path => path.Length != 0)
+            .Where(path => !IsWindowsProjection(path))
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))]);
+
+    private static readonly Lazy<MetadataReference> WindowsAppSdk = new(() =>
+        Compile("ReswPlusTests.WindowsAppSdkStub", WindowsAppSdkStub, @"C:\Packages\Microsoft.WindowsAppSdk\Microsoft.WindowsAppSdk.dll"));
+
+    private static readonly Lazy<MetadataReference> Uwp = new(() =>
+        Compile("ReswPlusTests.UwpStub", UwpStub, @"C:\Packages\UAP\Windows.Foundation.UniversalApiContract.winmd"));
+
+    /// <summary>
+    /// Returns the references a compilation of the given kind of app is built with.
+    /// </summary>
+    /// <param name="appType">The kind of app to describe.</param>
+    /// <returns>The references of the compilation.</returns>
+    public static ImmutableArray<MetadataReference> ReferencesFor(AppType appType)
+    {
+        return appType switch
+        {
+            AppType.WindowsAppSDK => RuntimeReferences.Value.Add(WindowsAppSdk.Value),
+            AppType.UWP => RuntimeReferences.Value.Add(Uwp.Value),
+            _ => RuntimeReferences.Value,
+        };
+    }
+
+    private static bool IsWindowsProjection(string path)
+    {
+        var name = Path.GetFileNameWithoutExtension(path);
+
+        return name.Equals("Microsoft.Windows.SDK.NET", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("WinRT.Runtime", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static MetadataReference Compile(string assemblyName, string source, string filePath)
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [CSharpSyntaxTree.ParseText(source)],
+            RuntimeReferences.Value,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var peStream = new MemoryStream();
+
+        var result = compilation.Emit(peStream);
+
+        if (!result.Success)
+        {
+            throw new InvalidOperationException(
+                $"The '{assemblyName}' stub does not compile:{Environment.NewLine}" +
+                string.Join(Environment.NewLine, result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        }
+
+        // The generator reads the kind of app off the name of the referenced files, so the stub is given the
+        // path the real framework would have.
+        return AssemblyMetadata.CreateFromImage(peStream.ToArray())
+            .GetReference(filePath: filePath, display: filePath);
+    }
+}

--- a/tests/ReswPlusUnitTests/ReswTestHelpers.cs
+++ b/tests/ReswPlusUnitTests/ReswTestHelpers.cs
@@ -129,22 +129,4 @@ internal static class ReswTestHelpers
     {
         return text.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
     }
-
-    private sealed class InMemoryAdditionalText : AdditionalText
-    {
-        private readonly SourceText _text;
-
-        public InMemoryAdditionalText(string path, string content)
-        {
-            Path = path;
-            _text = SourceText.From(content);
-        }
-
-        public override string Path { get; }
-
-        public override SourceText GetText(CancellationToken cancellationToken = default)
-        {
-            return _text;
-        }
-    }
 }


### PR DESCRIPTION
Adds an end-to-end test harness that runs the generator the way the compiler runs it.

## Why

The suite reached into `ReswClassGenerator` directly, which left everything the generator itself does untested: the MSBuild properties it reads, the kind of app it infers from the references of the compilation, the namespace it derives from the folder of a resource, the language it generates from, and the shared support sources it has to emit exactly once for a project holding several `.resw` files.

The emitted code was also only ever *parsed*, never compiled — so the failure a source generator is most prone to, emitting source that doesn't build in the consumer's project, could only be found by building a sample by hand.

## What

`ReswGeneratorHarness` drives the real `IIncrementalGenerator` through a `CSharpGeneratorDriver` over an in-memory project, then compiles what comes out against stubs of the UWP and Windows App SDK types the generated code binds to. Sources are parsed at the language version a UWP project uses by default (C# 7.3) and with documentation diagnostics on, so both guarantees the generated code already made are now enforced end to end.

32 tests cover: both app types, library vs application resource maps, the namespace derived from the folder, `DefaultLanguage` selection, multi-file and multi-language projects, the shared-support dedup, files the generator doesn't own, and every setup diagnostic (RESWP0001–0005, RESWP0011).

## Notes

Writing these immediately surfaced two real bugs in generated code that does not compile; both are fixed in the follow-up PR rather than here, so this one stays purely additive.

## Testing

340 tests pass.

