### PR TITLE
Split the pipeline so an edit costs one resource file

### DIFF
--- a/src/ReswPlus.SourceGenerator/Diagnostics.cs
+++ b/src/ReswPlus.SourceGenerator/Diagnostics.cs
@@ -193,4 +193,27 @@ internal static class Diagnostics
         ResourcesCategory,
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
+
+    /// <summary>
+    /// Returns the descriptor of a diagnostic from its identifier.
+    /// </summary>
+    /// <param name="id">The identifier of the diagnostic.</param>
+    /// <returns>The descriptor to report the diagnostic with.</returns>
+    /// <remarks>
+    /// A <see cref="DiagnosticDescriptor"/> compares by reference, so what is decided about the setup of a
+    /// project travels through the pipeline as identifiers and is resolved back here when it is reported.
+    /// Carrying the descriptors themselves would keep the stage from ever comparing equal to its previous run.
+    /// </remarks>
+    public static DiagnosticDescriptor GetDescriptor(string id)
+    {
+        return id switch
+        {
+            "RESWP0001" => UnsupportedLanguage,
+            "RESWP0002" => UnknownNamespace,
+            "RESWP0003" => MissingRootPath,
+            "RESWP0004" => UnknownProjectType,
+            "RESWP0005" => UnrecognizedAppType,
+            _ => throw new System.ArgumentOutOfRangeException(nameof(id), id, "No diagnostic carries that identifier."),
+        };
+    }
 }

--- a/src/ReswPlus.SourceGenerator/Pipeline/EquatableArray.cs
+++ b/src/ReswPlus.SourceGenerator/Pipeline/EquatableArray.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace ReswPlus.SourceGenerator.Pipeline;
+
+/// <summary>
+/// An array that compares equal to another one holding the same items.
+/// </summary>
+/// <typeparam name="T">The type of the items.</typeparam>
+/// <remarks>
+/// Everything that travels through the pipeline of an incremental generator is compared against the value the
+/// previous run produced, and whatever compares unequal is recomputed. <see cref="ImmutableArray{T}"/> compares
+/// by reference, so a stage returning one is recomputed on every run whatever it holds, and so is every stage
+/// below it.
+/// </remarks>
+internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnumerable<T>
+    where T : IEquatable<T>
+{
+    private readonly T[]? _items;
+
+    public EquatableArray(IEnumerable<T> items)
+    {
+        _items = items as T[] ?? items.ToArray();
+    }
+
+    /// <summary>
+    /// Gets the number of items.
+    /// </summary>
+    public int Count => _items?.Length ?? 0;
+
+    /// <summary>
+    /// Gets the item at the given position.
+    /// </summary>
+    public T this[int index] => _items![index];
+
+    /// <inheritdoc/>
+    public bool Equals(EquatableArray<T> other)
+    {
+        if (Count != other.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < Count; i++)
+        {
+            if (!EqualityComparer<T>.Default.Equals(this[i], other[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is EquatableArray<T> other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = 17;
+
+        for (var i = 0; i < Count; i++)
+        {
+            hash = (hash * 31) + (this[i]?.GetHashCode() ?? 0);
+        }
+
+        return hash;
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)(_items ?? [])).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/ReswPlus.SourceGenerator/Pipeline/ReswBuildOptions.cs
+++ b/src/ReswPlus.SourceGenerator/Pipeline/ReswBuildOptions.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace ReswPlus.SourceGenerator.Pipeline;
+
+/// <summary>
+/// The MSBuild properties the generation depends on.
+/// </summary>
+/// <remarks>
+/// The properties are read into a value of their own rather than being taken off the options provider where
+/// they are needed. The provider is a new object on every run, so a stage reading from it directly would never
+/// compare equal to the previous run and would be recomputed on every keystroke, along with everything below it.
+/// </remarks>
+internal sealed class ReswBuildOptions : IEquatable<ReswBuildOptions>
+{
+    private ReswBuildOptions(
+        string? projectDir,
+        string? msBuildProjectFullPath,
+        string? outputType,
+        string? projectTypeGuids,
+        string? defaultLanguage,
+        string? rootNamespace,
+        bool useApplicationLanguages)
+    {
+        ProjectDir = projectDir;
+        MSBuildProjectFullPath = msBuildProjectFullPath;
+        OutputType = outputType;
+        ProjectTypeGuids = projectTypeGuids;
+        DefaultLanguage = defaultLanguage;
+        RootNamespace = rootNamespace;
+        UseApplicationLanguages = useApplicationLanguages;
+    }
+
+    public string? ProjectDir { get; }
+
+    public string? MSBuildProjectFullPath { get; }
+
+    public string? OutputType { get; }
+
+    public string? ProjectTypeGuids { get; }
+
+    public string? DefaultLanguage { get; }
+
+    public string? RootNamespace { get; }
+
+    /// <summary>
+    /// Gets whether the project opted into reading the plural language from the app runtime language list, the
+    /// same list the resources themselves are resolved against.
+    /// </summary>
+    public bool UseApplicationLanguages { get; }
+
+    /// <summary>
+    /// Reads the properties of a project.
+    /// </summary>
+    /// <param name="globalOptions">The options of the compilation.</param>
+    /// <returns>The properties the generation depends on.</returns>
+    public static ReswBuildOptions Read(AnalyzerConfigOptions globalOptions)
+    {
+        return new ReswBuildOptions(
+            Get("build_property.projectdir"),
+            Get("build_property.MSBuildProjectFullPath"),
+            Get("build_property.OutputType"),
+            Get("build_property.projecttypeguids"),
+            Get("build_property.DefaultLanguage"),
+            Get("build_property.RootNamespace"),
+            bool.TryParse(Get("build_property.ReswPlusUseApplicationLanguages"), out var parsed) && parsed);
+
+        string? Get(string key) => globalOptions.TryGetValue(key, out var value) ? value : null;
+    }
+
+    /// <summary>
+    /// Returns the directory the project is rooted at.
+    /// </summary>
+    /// <returns>The root path of the project, or <see langword="null"/> when it cannot be determined.</returns>
+    public string? GetProjectRootPath()
+    {
+        if (ProjectDir is { Length: > 0 })
+        {
+            return ProjectDir;
+        }
+
+        return MSBuildProjectFullPath is { Length: > 0 } ? Path.GetDirectoryName(MSBuildProjectFullPath) : null;
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(ReswBuildOptions? other)
+    {
+        return other is not null
+            && ProjectDir == other.ProjectDir
+            && MSBuildProjectFullPath == other.MSBuildProjectFullPath
+            && OutputType == other.OutputType
+            && ProjectTypeGuids == other.ProjectTypeGuids
+            && DefaultLanguage == other.DefaultLanguage
+            && RootNamespace == other.RootNamespace
+            && UseApplicationLanguages == other.UseApplicationLanguages;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => Equals(obj as ReswBuildOptions);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = 17;
+
+        foreach (var value in new[] { ProjectDir, MSBuildProjectFullPath, OutputType, ProjectTypeGuids, DefaultLanguage, RootNamespace })
+        {
+            hash = (hash * 31) + (value?.GetHashCode() ?? 0);
+        }
+
+        return (hash * 31) + UseApplicationLanguages.GetHashCode();
+    }
+}

--- a/src/ReswPlus.SourceGenerator/Pipeline/ReswGeneratedFile.cs
+++ b/src/ReswPlus.SourceGenerator/Pipeline/ReswGeneratedFile.cs
@@ -1,0 +1,89 @@
+using System;
+
+namespace ReswPlus.SourceGenerator.Pipeline;
+
+/// <summary>
+/// The outcome of generating the code of one resource file.
+/// </summary>
+/// <remarks>
+/// This is what the per file stage of the pipeline produces, and it is compared against what the previous run
+/// produced to decide whether the file has to be emitted again. It therefore holds the generated text itself
+/// rather than a handle to whatever produced it, so that two runs over an unchanged resource file compare equal.
+/// </remarks>
+internal sealed class ReswGeneratedFile : IEquatable<ReswGeneratedFile>
+{
+    private ReswGeneratedFile(string sourcePath, string hintName, string? content, string? error, bool containsMacro, bool containsPlural)
+    {
+        SourcePath = sourcePath;
+        HintName = hintName;
+        Content = content;
+        Error = error;
+        ContainsMacro = containsMacro;
+        ContainsPlural = containsPlural;
+    }
+
+    /// <summary>
+    /// Gets the path of the resource file the code was generated from.
+    /// </summary>
+    public string SourcePath { get; }
+
+    /// <summary>
+    /// Gets the hint name to emit the code under.
+    /// </summary>
+    public string HintName { get; }
+
+    /// <summary>
+    /// Gets the generated code, or <see langword="null"/> when the resource file could not be read.
+    /// </summary>
+    public string? Content { get; }
+
+    /// <summary>
+    /// Gets why the resource file could not be turned into code, if it could not.
+    /// </summary>
+    public string? Error { get; }
+
+    /// <summary>
+    /// Gets whether the generated code uses the macros of ReswPlus, whose support is shared by the project.
+    /// </summary>
+    public bool ContainsMacro { get; }
+
+    /// <summary>
+    /// Gets whether the generated code looks resources up by quantity, whose support is shared by the project.
+    /// </summary>
+    public bool ContainsPlural { get; }
+
+    public static ReswGeneratedFile Generated(string sourcePath, string hintName, string content, bool containsMacro, bool containsPlural) =>
+        new(sourcePath, hintName, content, null, containsMacro, containsPlural);
+
+    public static ReswGeneratedFile Failed(string sourcePath, string hintName, string error) =>
+        new(sourcePath, hintName, null, error, false, false);
+
+    /// <inheritdoc/>
+    public bool Equals(ReswGeneratedFile? other)
+    {
+        return other is not null
+            && SourcePath == other.SourcePath
+            && HintName == other.HintName
+            && Content == other.Content
+            && Error == other.Error
+            && ContainsMacro == other.ContainsMacro
+            && ContainsPlural == other.ContainsPlural;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => Equals(obj as ReswGeneratedFile);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = 17;
+
+        hash = (hash * 31) + SourcePath.GetHashCode();
+        hash = (hash * 31) + HintName.GetHashCode();
+        hash = (hash * 31) + (Content?.GetHashCode() ?? 0);
+        hash = (hash * 31) + (Error?.GetHashCode() ?? 0);
+        hash = (hash * 31) + ContainsMacro.GetHashCode();
+
+        return (hash * 31) + ContainsPlural.GetHashCode();
+    }
+}

--- a/src/ReswPlus.SourceGenerator/Pipeline/ReswLayout.cs
+++ b/src/ReswPlus.SourceGenerator/Pipeline/ReswLayout.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ReswPlus.SourceGenerator.Analysis;
+using ReswPlus.SourceGenerator.CodeGenerators;
+
+namespace ReswPlus.SourceGenerator.Pipeline;
+
+/// <summary>
+/// A name paired with the path of the resource file it belongs to.
+/// </summary>
+internal readonly struct NamedPath : IEquatable<NamedPath>
+{
+    public NamedPath(string name, string path)
+    {
+        Name = name;
+        Path = path;
+    }
+
+    public string Name { get; }
+
+    public string Path { get; }
+
+    /// <inheritdoc/>
+    public bool Equals(NamedPath other) => Name == other.Name && Path == other.Path;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is NamedPath other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => (Name.GetHashCode() * 31) + Path.GetHashCode();
+}
+
+/// <summary>
+/// How the resource files of a project are laid out: which one of each resource carries the default language,
+/// and which languages the project is translated in.
+/// </summary>
+/// <remarks>
+/// This is derived from the paths of the resource files alone, never from their content, so that editing a
+/// string does not make the whole project regroup. It only changes when a resource file is added, removed or
+/// renamed.
+/// </remarks>
+internal sealed class ReswLayout : IEquatable<ReswLayout>
+{
+    private Dictionary<string, string>? _hintNamesByPath;
+
+    private ReswLayout(EquatableArray<NamedPath> generatedFiles, EquatableArray<NamedPath> languages)
+    {
+        GeneratedFiles = generatedFiles;
+        Languages = languages;
+    }
+
+    /// <summary>
+    /// Gets the resource files the code is generated from, each paired with the hint name to emit it under.
+    /// </summary>
+    public EquatableArray<NamedPath> GeneratedFiles { get; }
+
+    /// <summary>
+    /// Gets a resource file of each language of the project, so that a diagnostic about a language has
+    /// somewhere to point.
+    /// </summary>
+    public EquatableArray<NamedPath> Languages { get; }
+
+    /// <summary>
+    /// Works out the layout of a project.
+    /// </summary>
+    /// <param name="paths">The paths of the resource files of the project.</param>
+    /// <param name="defaultLanguage">The default language of the project, if it declares one.</param>
+    /// <param name="resolveNamespace">Returns the namespace the class of a resource file lands in, which qualifies its hint name so that two resources of the same name in different folders don't collide.</param>
+    /// <returns>The layout of the project.</returns>
+    public static ReswLayout Create(IEnumerable<string> paths, string? defaultLanguage, Func<string, string> resolveNamespace)
+    {
+        var allPaths = paths.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+
+        var defaultPaths = ReswFileGrouping.GroupByResource(allPaths)
+            .Select(group => ReswFileGrouping.RetrieveDefaultResourceFile(group, defaultLanguage))
+            .Where(path => path is not null)
+            .Select(path => path!)
+            .ToArray();
+
+        // Two resource files can carry the same name in different folders, so the hint name is qualified with
+        // the namespace the class lands in. Emitting the same hint name twice throws, and used to make the
+        // generator produce nothing at all for the whole project, so what is left is disambiguated rather than
+        // trusted.
+        var taken = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var generatedFiles = new List<NamedPath>();
+
+        foreach (var path in defaultPaths)
+        {
+            var hintName = $"{resolveNamespace(path)}.{Path.GetFileName(path)}{GeneratedCode.FileExtension}";
+
+            if (!taken.Add(hintName))
+            {
+                var suffix = 2;
+
+                while (!taken.Add($"{resolveNamespace(path)}.{Path.GetFileName(path)}.{suffix}{GeneratedCode.FileExtension}"))
+                {
+                    ++suffix;
+                }
+
+                hintName = $"{resolveNamespace(path)}.{Path.GetFileName(path)}.{suffix}{GeneratedCode.FileExtension}";
+            }
+
+            generatedFiles.Add(new NamedPath(hintName, path));
+        }
+
+        // The folder of a resource is reduced to its language exactly the way the generated code reduces the
+        // language of the app, so that the two always agree: a culture-sensitive ToLower would turn 'IS-IS'
+        // into 'ıs' under Turkish and never match again.
+        var languages = new List<NamedPath>();
+        var seenLanguages = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var path in allPaths)
+        {
+            var language = Path.GetFileName(Path.GetDirectoryName(path)).Split('-', '_')[0].ToLowerInvariant();
+
+            if (seenLanguages.Add(language))
+            {
+                languages.Add(new NamedPath(language, path));
+            }
+        }
+
+        return new ReswLayout(new EquatableArray<NamedPath>(generatedFiles), new EquatableArray<NamedPath>(languages));
+    }
+
+    /// <summary>
+    /// Returns the hint name to emit the code of a resource file under.
+    /// </summary>
+    /// <param name="path">The path of the resource file.</param>
+    /// <returns>The hint name, or <see langword="null"/> when the file is not the one the code is generated from.</returns>
+    public string? GetHintName(string path)
+    {
+        _hintNamesByPath ??= GeneratedFiles.ToDictionary(file => file.Path, file => file.Name, StringComparer.OrdinalIgnoreCase);
+
+        return _hintNamesByPath.TryGetValue(path, out var hintName) ? hintName : null;
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(ReswLayout? other)
+    {
+        return other is not null && GeneratedFiles.Equals(other.GeneratedFiles) && Languages.Equals(other.Languages);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => Equals(obj as ReswLayout);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => (GeneratedFiles.GetHashCode() * 31) + Languages.GetHashCode();
+}

--- a/src/ReswPlus.SourceGenerator/Pipeline/ReswProject.cs
+++ b/src/ReswPlus.SourceGenerator/Pipeline/ReswProject.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace ReswPlus.SourceGenerator.Pipeline;
+
+/// <summary>
+/// What the generation needs to know about the project, resolved once.
+/// </summary>
+internal sealed class ReswProject : IEquatable<ReswProject>
+{
+    private ReswProject(
+        bool isSupported,
+        AppType appType,
+        string assemblyName,
+        string projectRootPath,
+        string rootNamespace,
+        bool isLibrary,
+        bool useApplicationLanguages,
+        string? defaultLanguage,
+        EquatableArray<string> setupProblems)
+    {
+        DefaultLanguage = defaultLanguage;
+        IsSupported = isSupported;
+        AppType = appType;
+        AssemblyName = assemblyName;
+        ProjectRootPath = projectRootPath;
+        RootNamespace = rootNamespace;
+        IsLibrary = isLibrary;
+        UseApplicationLanguages = useApplicationLanguages;
+        SetupProblems = setupProblems;
+    }
+
+    /// <summary>
+    /// Gets whether the project is one ReswPlus can generate code for.
+    /// </summary>
+    public bool IsSupported { get; }
+
+    public AppType AppType { get; }
+
+    public string AssemblyName { get; }
+
+    public string ProjectRootPath { get; }
+
+    public string RootNamespace { get; }
+
+    public bool IsLibrary { get; }
+
+    public bool UseApplicationLanguages { get; }
+
+    /// <summary>
+    /// Gets the default language of the project, which picks the resource file the code is generated from.
+    /// </summary>
+    public string? DefaultLanguage { get; }
+
+    /// <summary>
+    /// Gets the identifiers of the diagnostics to report about the setup of the project.
+    /// </summary>
+    /// <remarks>
+    /// The descriptors themselves are resolved when the diagnostics are reported, rather than being carried
+    /// here: a <see cref="DiagnosticDescriptor"/> compares by reference, which would keep this value from ever
+    /// comparing equal to the one of the previous run.
+    /// </remarks>
+    public EquatableArray<string> SetupProblems { get; }
+
+    /// <summary>
+    /// Resolves what the generation needs from the compilation and the properties of the project.
+    /// </summary>
+    /// <param name="compilationInfo">What the generation depends on in the compilation.</param>
+    /// <param name="options">The properties of the project.</param>
+    /// <returns>The resolved project.</returns>
+    public static ReswProject Create(CompilationInfo compilationInfo, ReswBuildOptions options)
+    {
+        var problems = new List<string>();
+
+        if (!compilationInfo.IsCSharp)
+        {
+            return Unsupported(Diagnostics.UnsupportedLanguage.Id);
+        }
+
+        var projectRootPath = options.GetProjectRootPath();
+
+        if (string.IsNullOrEmpty(projectRootPath))
+        {
+            return Unsupported(Diagnostics.MissingRootPath.Id);
+        }
+
+        var isLibrary = false;
+
+        if (options.OutputType is { Length: > 0 })
+        {
+            isLibrary = options.OutputType.Equals("library", StringComparison.OrdinalIgnoreCase)
+                     || options.OutputType.Equals("module", StringComparison.OrdinalIgnoreCase);
+        }
+        else if (options.ProjectTypeGuids is { Length: > 0 })
+        {
+            isLibrary = options.ProjectTypeGuids.Equals("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase)
+                     || options.ProjectTypeGuids.Equals("{BC8A1FFA-BEE3-4634-8014-F334798102B3}", StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            problems.Add(Diagnostics.UnknownProjectType.Id);
+        }
+
+        if (compilationInfo.AppType is not (AppType.WindowsAppSDK or AppType.UWP))
+        {
+            return Unsupported([.. problems, Diagnostics.UnrecognizedAppType.Id]);
+        }
+
+        if (string.IsNullOrEmpty(options.RootNamespace))
+        {
+            return Unsupported([.. problems, Diagnostics.UnknownNamespace.Id]);
+        }
+
+        return new ReswProject(
+            isSupported: true,
+            compilationInfo.AppType,
+            compilationInfo.AssemblyName ?? "",
+            projectRootPath!,
+            options.RootNamespace!,
+            isLibrary,
+            options.UseApplicationLanguages,
+            options.DefaultLanguage,
+            new EquatableArray<string>(problems));
+
+        ReswProject Unsupported(params string[] problems) =>
+            new(false, AppType.Unknown, "", "", "", false, false, options.DefaultLanguage, new EquatableArray<string>(problems));
+    }
+
+    /// <summary>
+    /// Returns the namespace the class generated for a resource file is declared in.
+    /// </summary>
+    /// <param name="resourceFilePath">The path of the resource file.</param>
+    /// <returns>The namespace, which follows the folder the resource file sits in.</returns>
+    public string GetNamespace(string resourceFilePath)
+    {
+        var directory = Path.GetDirectoryName(resourceFilePath);
+
+        if (directory is null || !directory.StartsWith(ProjectRootPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return RootNamespace;
+        }
+
+        var relative = directory.Substring(ProjectRootPath.Length)
+            .Trim(Path.DirectorySeparatorChar)
+            .Replace(Path.DirectorySeparatorChar, '.');
+
+        return relative.Length == 0 ? RootNamespace : $"{RootNamespace}.{relative}";
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(ReswProject? other)
+    {
+        return other is not null
+            && IsSupported == other.IsSupported
+            && AppType == other.AppType
+            && AssemblyName == other.AssemblyName
+            && ProjectRootPath == other.ProjectRootPath
+            && RootNamespace == other.RootNamespace
+            && IsLibrary == other.IsLibrary
+            && UseApplicationLanguages == other.UseApplicationLanguages
+            && DefaultLanguage == other.DefaultLanguage
+            && SetupProblems.Equals(other.SetupProblems);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => Equals(obj as ReswProject);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = 17;
+
+        hash = (hash * 31) + IsSupported.GetHashCode();
+        hash = (hash * 31) + AppType.GetHashCode();
+        hash = (hash * 31) + AssemblyName.GetHashCode();
+        hash = (hash * 31) + ProjectRootPath.GetHashCode();
+        hash = (hash * 31) + RootNamespace.GetHashCode();
+        hash = (hash * 31) + IsLibrary.GetHashCode();
+        hash = (hash * 31) + UseApplicationLanguages.GetHashCode();
+        hash = (hash * 31) + (DefaultLanguage?.GetHashCode() ?? 0);
+
+        return (hash * 31) + SetupProblems.GetHashCode();
+    }
+}

--- a/src/ReswPlus.SourceGenerator/Pipeline/ReswSupport.cs
+++ b/src/ReswPlus.SourceGenerator/Pipeline/ReswSupport.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+
+namespace ReswPlus.SourceGenerator.Pipeline;
+
+/// <summary>
+/// The support sources shared by every resource file of a project.
+/// </summary>
+/// <remarks>
+/// Which of them are needed depends on what the resource files of the project use, so this can only be decided
+/// once every file has been generated. It is deliberately reduced to a handful of flags and the languages of
+/// the project: editing a string changes the code generated for its file, but almost never changes any of
+/// this, so the support sources are emitted once and then left alone.
+/// </remarks>
+internal sealed class ReswSupport : IEquatable<ReswSupport>
+{
+    private ReswSupport(bool isSupported, AppType appType, bool needsMacros, bool needsPlurals, bool useApplicationLanguages, EquatableArray<NamedPath> languages)
+    {
+        IsSupported = isSupported;
+        AppType = appType;
+        NeedsMacros = needsMacros;
+        NeedsPlurals = needsPlurals;
+        UseApplicationLanguages = useApplicationLanguages;
+        Languages = languages;
+    }
+
+    public bool IsSupported { get; }
+
+    public AppType AppType { get; }
+
+    public bool NeedsMacros { get; }
+
+    public bool NeedsPlurals { get; }
+
+    public bool UseApplicationLanguages { get; }
+
+    /// <summary>
+    /// Gets a resource file of each language of the project, so that a diagnostic about a language has
+    /// somewhere to point.
+    /// </summary>
+    public EquatableArray<NamedPath> Languages { get; }
+
+    /// <summary>
+    /// Works out which support sources the project needs.
+    /// </summary>
+    /// <param name="generatedFiles">The code generated for each resource file of the project.</param>
+    /// <param name="project">The project the code is generated for.</param>
+    /// <param name="layout">How the resource files of the project are laid out.</param>
+    /// <returns>The support the project needs.</returns>
+    public static ReswSupport Create(System.Collections.Immutable.ImmutableArray<ReswGeneratedFile> generatedFiles, ReswProject project, ReswLayout layout)
+    {
+        if (!project.IsSupported)
+        {
+            return new ReswSupport(false, AppType.Unknown, false, false, false, new EquatableArray<NamedPath>([]));
+        }
+
+        return new ReswSupport(
+            isSupported: true,
+            project.AppType,
+            generatedFiles.Any(file => file.ContainsMacro),
+            generatedFiles.Any(file => file.ContainsPlural),
+            project.UseApplicationLanguages,
+            layout.Languages);
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(ReswSupport? other)
+    {
+        return other is not null
+            && IsSupported == other.IsSupported
+            && AppType == other.AppType
+            && NeedsMacros == other.NeedsMacros
+            && NeedsPlurals == other.NeedsPlurals
+            && UseApplicationLanguages == other.UseApplicationLanguages
+            && Languages.Equals(other.Languages);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => Equals(obj as ReswSupport);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        var hash = 17;
+
+        hash = (hash * 31) + IsSupported.GetHashCode();
+        hash = (hash * 31) + AppType.GetHashCode();
+        hash = (hash * 31) + NeedsMacros.GetHashCode();
+        hash = (hash * 31) + NeedsPlurals.GetHashCode();
+        hash = (hash * 31) + UseApplicationLanguages.GetHashCode();
+
+        return (hash * 31) + Languages.GetHashCode();
+    }
+}

--- a/src/ReswPlus.SourceGenerator/Pipeline/TrackingNames.cs
+++ b/src/ReswPlus.SourceGenerator/Pipeline/TrackingNames.cs
@@ -1,0 +1,27 @@
+namespace ReswPlus.SourceGenerator.Pipeline;
+
+/// <summary>
+/// The names the stages of the pipeline are tracked under.
+/// </summary>
+/// <remarks>
+/// Tracking a stage is what lets a test observe whether the generator reused what it had computed before or
+/// recomputed it. Without it, the incremental behaviour of the generator can only be described, not asserted,
+/// and a change that quietly makes the whole project regenerate on every keystroke looks exactly like one that
+/// doesn't.
+/// </remarks>
+internal static class TrackingNames
+{
+    public const string Options = "ReswPlus.Options";
+
+    public const string CompilationInfo = "ReswPlus.CompilationInfo";
+
+    public const string Project = "ReswPlus.Project";
+
+    public const string Paths = "ReswPlus.Paths";
+
+    public const string Layout = "ReswPlus.Layout";
+
+    public const string Generation = "ReswPlus.Generation";
+
+    public const string Support = "ReswPlus.Support";
+}

--- a/src/ReswPlus.SourceGenerator/ReswGenerator.cs
+++ b/src/ReswPlus.SourceGenerator/ReswGenerator.cs
@@ -1,17 +1,18 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
-using ReswPlus.SourceGenerator.Analysis;
 using ReswPlus.SourceGenerator.ClassGenerators;
 using ReswPlus.SourceGenerator.CodeGenerators;
 using ReswPlus.SourceGenerator.Models;
-using Microsoft.CodeAnalysis.Diagnostics;
+using ReswPlus.SourceGenerator.Pipeline;
 
 #if DEBUG
 using System.Diagnostics;
@@ -26,9 +27,30 @@ public enum AppType
     UWP,
 }
 
+/// <summary>
+/// Generates the strongly typed classes of the <c>.resw</c> files of a project.
+/// </summary>
+/// <remarks>
+/// The pipeline is split so that editing one resource file only costs the work of that file. Everything that
+/// can be decided without reading a resource file -- the properties of the project, the kind of app, which
+/// file of each resource carries the default language -- is decided in a stage of its own, and the reading,
+/// parsing and generation of a resource file happens in a stage that runs once per file. The compiler keeps
+/// the result of every stage between runs and only reruns the ones whose inputs changed, so how the stages are
+/// split is what decides the cost of a keystroke in the IDE.
+/// </remarks>
 [Generator]
 public partial class ReswSourceGenerator : IIncrementalGenerator
 {
+    /// <summary>
+    /// The templates, decoded once.
+    /// </summary>
+    /// <remarks>
+    /// The templates are immutable resources baked into this assembly, and the compiler keeps a generator alive
+    /// for as long as the project is open, so reading and decoding them off a manifest stream on every run is
+    /// pure repetition.
+    /// </remarks>
+    private static readonly ConcurrentDictionary<string, string> Templates = new(StringComparer.Ordinal);
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
 #if DEBUG
@@ -39,245 +61,190 @@ public partial class ReswSourceGenerator : IIncrementalGenerator
         }
 #endif
 
-        // Create a provider for global analyzer config options.
-        var globalOptionsProvider = context.AnalyzerConfigOptionsProvider.Select((options, cancellationToken) => new
-        {
-            ProjectDir = GetOption(options.GlobalOptions, "build_property.projectdir"),
-            MSBuildProjectFullPath = GetOption(options.GlobalOptions, "build_property.MSBuildProjectFullPath"),
-            OutputType = GetOption(options.GlobalOptions, "build_property.OutputType"),
-            ProjectTypeGuids = GetOption(options.GlobalOptions, "build_property.projecttypeguids"),
-            DefaultLanguage = GetOption(options.GlobalOptions, "build_property.DefaultLanguage"),
-            RootNamespace = GetOption(options.GlobalOptions, "build_property.RootNamespace"),
-            UseApplicationLanguages = GetOption(options.GlobalOptions, "build_property.ReswPlusUseApplicationLanguages")
-        });
+        // The properties of the project are read into a value of their own: the options provider is a new
+        // object on every run, so anything reading from it directly would be recomputed on every keystroke.
+        var options = context.AnalyzerConfigOptionsProvider
+            .Select(static (provider, _) => ReswBuildOptions.Read(provider.GlobalOptions))
+            .WithTrackingName(TrackingNames.Options);
 
-        // Provider for additional files with .resw extension.
-        var reswFilesProvider = context.AdditionalTextsProvider
-            .Where(file => Path.GetExtension(file.Path).Equals(".resw", StringComparison.OrdinalIgnoreCase))
-            .Collect();
+        // Only the parts of the compilation the generation actually depends on are captured, for the same
+        // reason: a Compilation is a new object every time.
+        var compilationInfo = context.CompilationProvider
+            .Select(static (compilation, _) =>
+                new CompilationInfo(compilation is CSharpCompilation, RetrieveAppType(compilation), compilation.AssemblyName))
+            .WithTrackingName(TrackingNames.CompilationInfo);
 
-        // Only the parts of the compilation the generation actually depends on are captured, so that an unrelated
-        // edit in the project doesn't invalidate the whole pipeline: a Compilation is a new object every time.
-        var compilationInfoProvider = context.CompilationProvider.Select(static (compilation, cancellationToken) =>
-            new CompilationInfo(compilation is CSharpCompilation, RetrieveAppType(compilation), compilation.AssemblyName));
+        var project = compilationInfo
+            .Combine(options)
+            .Select(static (pair, _) => ReswProject.Create(pair.Left, pair.Right))
+            .WithTrackingName(TrackingNames.Project);
 
-        // Combine the compilation information, the global options, and the additional files.
-        var combinedProvider = compilationInfoProvider
-            .Combine(globalOptionsProvider)
-            .Combine(reswFilesProvider);
+        var resourceFiles = context.AdditionalTextsProvider
+            .Where(static file => Path.GetExtension(file.Path).Equals(".resw", StringComparison.OrdinalIgnoreCase));
 
-        context.RegisterSourceOutput(combinedProvider, static (spc, source) =>
-        {
-            // Unpack the combined tuple.
-            var ((compilationInfo, options), additionalFiles) = source;
+        // The layout is derived from the paths alone, never from the content of the files, so that editing a
+        // string does not make the whole project regroup.
+        var layout = resourceFiles
+            .Select(static (file, _) => file.Path)
+            .WithTrackingName(TrackingNames.Paths)
+            .Collect()
+            .Combine(project)
+            .Select(static (pair, _) => ReswLayout.Create(pair.Left, pair.Right.DefaultLanguage, pair.Right.GetNamespace))
+            .WithTrackingName(TrackingNames.Layout);
 
-            if (options is null)
-            {
-                return;
-            }
+        // One run per resource file, so that editing one of them leaves the others alone.
+        var generated = resourceFiles
+            .Combine(project)
+            .Combine(layout)
+            .Select(static (input, cancellationToken) =>
+                GenerateFile(input.Left.Left, input.Left.Right, input.Right, cancellationToken))
+            .Where(static file => file is not null)
+            .Select(static (file, _) => file!)
+            .WithTrackingName(TrackingNames.Generation);
 
-            // Only support C#
-            if (!compilationInfo.IsCSharp)
-            {
-                spc.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnsupportedLanguage, Location.None));
-                return;
-            }
+        // Which support sources the project needs can only be decided once every file has been generated, but
+        // it comes down to a handful of flags that almost never change while a project is edited.
+        var support = generated
+            .Collect()
+            .Combine(project)
+            .Combine(layout)
+            .Select(static (input, _) => ReswSupport.Create(input.Left.Left, input.Left.Right, input.Right))
+            .WithTrackingName(TrackingNames.Support);
 
-            // Retrieve project root path.
-            var projectRootPath = options.ProjectDir;
-            if (projectRootPath is not { Length: > 0 } && options.MSBuildProjectFullPath is { Length: > 0 })
-            {
-                projectRootPath = Path.GetDirectoryName(options.MSBuildProjectFullPath);
-            }
-
-            if (string.IsNullOrEmpty(projectRootPath))
-            {
-                spc.ReportDiagnostic(Diagnostic.Create(Diagnostics.MissingRootPath, Location.None));
-                return;
-            }
-
-            // Determine if the project is a library.
-            bool isLibrary = false;
-            if (options.OutputType is { Length: > 0 })
-            {
-                isLibrary = options.OutputType.Equals("library", StringComparison.OrdinalIgnoreCase)
-                         || options.OutputType.Equals("module", StringComparison.OrdinalIgnoreCase);
-            }
-            else if (options.ProjectTypeGuids is { Length: > 0 })
-            {
-                isLibrary = options.ProjectTypeGuids.Equals("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", StringComparison.OrdinalIgnoreCase)
-                         || options.ProjectTypeGuids.Equals("{BC8A1FFA-BEE3-4634-8014-F334798102B3}", StringComparison.OrdinalIgnoreCase);
-            }
-            else
-            {
-                spc.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnknownProjectType, Location.None));
-            }
-
-            // Determine AppType based on referenced assemblies.
-            var appType = compilationInfo.AppType;
-            var assemblyName = Assembly.GetExecutingAssembly().GetName().Name;
-
-            // The support sources are shared by every resource file of the project, so they are emitted once.
-            // Adding the same hint name twice throws, which used to make the generator produce nothing at all
-            // for a project holding more than one .resw that uses macros or plurals.
-            var emittedSources = new HashSet<string>(StringComparer.Ordinal);
-
-            // Opt in to reading the plural language from the app runtime language list, the same list the
-            // resources themselves are resolved against.
-            var useApplicationLanguages =
-                bool.TryParse(options.UseApplicationLanguages, out var parsedUseApplicationLanguages) && parsedUseApplicationLanguages;
-
-            switch (appType)
-            {
-                case AppType.WindowsAppSDK:
-                    AddSourceFromResource(spc, emittedSources, $"{assemblyName}.Templates.ResourceStringProviders.MicrosoftResourceStringProvider.txt", "ResourceStringProvider");
-                    break;
-                case AppType.UWP:
-                    AddSourceFromResource(spc, emittedSources, $"{assemblyName}.Templates.ResourceStringProviders.WindowsResourceStringProvider.txt", "ResourceStringProvider");
-                    break;
-                default:
-                    spc.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnrecognizedAppType, Location.None));
-                    return;
-            }
-
-            // Retrieve the default language (optional)
-            var projectDefaultLanguage = options.DefaultLanguage;
-
-            // Retrieve the project's root namespace.
-            if (string.IsNullOrEmpty(options.RootNamespace))
-            {
-                spc.ReportDiagnostic(Diagnostic.Create(Diagnostics.UnknownNamespace, Location.None));
-                return;
-            }
-            var projectRootNamespace = options.RootNamespace!;
-
-            // Process all .resw additional files.
-            var allResourceFiles = additionalFiles.Distinct().ToArray();
-
-            // Group files and retrieve the default resource file per group.
-            var defaultLanguageResourceFiles = (from fileGroup in ReswFileGrouping.GroupByResource(allResourceFiles.Select(file => file.Path))
-                                                let defaultFile = ReswFileGrouping.RetrieveDefaultResourceFile(
-                                                    fileGroup,
-                                                    projectDefaultLanguage)
-                                                where defaultFile != null
-                                                select defaultFile).ToArray();
-
-            // Gather all distinct languages, keeping a resource file for each so that a diagnostic about a
-            // language has somewhere to point. The folder of a resource is reduced to its language exactly the
-            // way the generated code reduces the language of the app, so that the two always agree: a
-            // culture-sensitive ToLower would turn 'IS-IS' into 'ıs' under Turkish and never match again.
-            var resourceFilePerLanguage = new Dictionary<string, string>(StringComparer.Ordinal);
-            foreach (var resourceFile in allResourceFiles)
-            {
-                var language = Path.GetFileName(Path.GetDirectoryName(resourceFile.Path)).Split('-', '_')[0].ToLowerInvariant();
-                if (!resourceFilePerLanguage.ContainsKey(language))
-                {
-                    resourceFilePerLanguage.Add(language, resourceFile.Path);
-                }
-            }
-
-            // Process each default resource file.
-            foreach (var filePath in defaultLanguageResourceFiles)
-            {
-                // Determine namespace for the generated class.
-                var namespaceForReswFile = projectRootNamespace;
-                var reswParentDirectory = Path.GetDirectoryName(filePath);
-                if (reswParentDirectory != null && reswParentDirectory.StartsWith(projectRootPath, StringComparison.OrdinalIgnoreCase))
-                {
-                    var additionalNamespace = reswParentDirectory.Substring(projectRootPath!.Length)
-                        .Trim(Path.DirectorySeparatorChar)
-                        .Replace(Path.DirectorySeparatorChar, '.');
-                    if (!string.IsNullOrEmpty(additionalNamespace))
-                    {
-                        namespaceForReswFile += "." + additionalNamespace;
-                    }
-                }
-
-                // Get the additional file matching this path.
-                var additionalText = allResourceFiles.FirstOrDefault(f => f.Path == filePath);
-                if (additionalText is null)
-                {
-                    continue;
-                }
-
-                // Generate code for the resource file.
-                var resourceFileInfo = new ResourceFileInfo(filePath, new Project(compilationInfo.AssemblyName!, isLibrary));
-                var codeGenerator = ReswClassGenerator.CreateGenerator(resourceFileInfo, null);
-                if (codeGenerator is null)
-                {
-                    continue;
-                }
-
-                var baseFilename = Path.GetFileName(filePath).Split('.')[0];
-                var text = additionalText.GetText(spc.CancellationToken)?.ToString() ?? "";
-
-                GenerationResult? generatedData;
-
-                // Whatever a resource file holds, and however malformed it is, it must not take the generation
-                // of the rest of the project down with it: an exception escaping here is reported by the
-                // compiler as a single CS8785 that names neither the file nor the reason, and no resource file
-                // of the project is generated at all.
-                try
-                {
-                    generatedData = codeGenerator.GenerateCode(
-                        baseFilename: baseFilename,
-                        content: text,
-                        defaultNamespace: namespaceForReswFile,
-                        isAdvanced: true,
-                        appType: appType);
-                }
-                catch (Exception exception)
-                {
-                    spc.ReportDiagnostic(Diagnostic.Create(
-                        Diagnostics.ResourceFileNotProcessed,
-                        CreateFileLocation(filePath),
-                        Path.GetFileName(filePath),
-                        exception.Message));
-
-                    continue;
-                }
-
-                if (generatedData is null)
-                {
-                    continue;
-                }
-
-                // Add each generated file as a new source. The hint name is qualified with the namespace of the
-                // resource file, because two .resw files with the same name can live in different folders.
-                foreach (var generatedFile in generatedData.Files)
-                {
-                    var hintName = $"{namespaceForReswFile}.{Path.GetFileName(filePath)}{GeneratedCode.FileExtension}";
-                    if (emittedSources.Add(hintName))
-                    {
-                        spc.AddSource(hintName, SourceText.From(generatedFile.Content, Encoding.UTF8));
-                    }
-                }
-
-                // If macros were used, include the Macros source file.
-                if (generatedData.ContainsMacro)
-                {
-                    AddSourceFromResource(spc, emittedSources, "ReswPlus.SourceGenerator.Templates.Macros.Macros.txt", "Macros");
-                }
-
-                // If plural forms are detected, add plural-related support sources.
-                if (generatedData.ContainsPlural)
-                {
-                    AddSourceFromResource(spc, emittedSources, $"{assemblyName}.Templates.Plurals.IPluralProvider.txt", "IPluralProvider");
-                    AddSourceFromResource(spc, emittedSources, $"{assemblyName}.Templates.Plurals.PluralTypeEnum.txt", "PluralTypeEnum");
-                    AddSourceFromResource(spc, emittedSources, $"{assemblyName}.Templates.Utils.IntExt.txt", "IntExt");
-                    AddSourceFromResource(spc, emittedSources, $"{assemblyName}.Templates.Utils.DoubleExt.txt", "DoubleExt");
-                    AddLanguageSupport(spc, emittedSources, resourceFilePerLanguage, useApplicationLanguages, appType);
-                }
-            }
-        });
+        context.RegisterSourceOutput(project, static (spc, project) => ReportSetupProblems(spc, project));
+        context.RegisterSourceOutput(generated, static (spc, file) => EmitGeneratedFile(spc, file));
+        context.RegisterSourceOutput(support, static (spc, support) => EmitSupport(spc, support));
     }
 
     /// <summary>
-    /// Helper method to retrieve an option value.
+    /// Reports what is wrong with the setup of the project, if anything is.
     /// </summary>
-    private static string? GetOption(AnalyzerConfigOptions globalOptions, string key)
+    private static void ReportSetupProblems(SourceProductionContext spc, ReswProject project)
     {
-        return globalOptions.TryGetValue(key, out var value) ? value : null;
+        foreach (var id in project.SetupProblems)
+        {
+            spc.ReportDiagnostic(Diagnostic.Create(Diagnostics.GetDescriptor(id), Location.None));
+        }
+    }
+
+    /// <summary>
+    /// Generates the code of one resource file.
+    /// </summary>
+    /// <param name="file">The resource file.</param>
+    /// <param name="project">The project the code is generated for.</param>
+    /// <param name="layout">How the resource files of the project are laid out.</param>
+    /// <param name="cancellationToken">The token used to cancel the operation.</param>
+    /// <returns>
+    /// The generated code, or <see langword="null"/> when the file holds a translation rather than the
+    /// language the code is generated from, or when the project is not one ReswPlus supports.
+    /// </returns>
+    private static ReswGeneratedFile? GenerateFile(AdditionalText file, ReswProject project, ReswLayout layout, CancellationToken cancellationToken)
+    {
+        if (!project.IsSupported || layout.GetHintName(file.Path) is not { } hintName)
+        {
+            return null;
+        }
+
+        var resourceFileInfo = new ResourceFileInfo(file.Path, new Project(project.AssemblyName, project.IsLibrary));
+        var codeGenerator = ReswClassGenerator.CreateGenerator(resourceFileInfo, null);
+
+        if (codeGenerator is null)
+        {
+            return null;
+        }
+
+        var content = file.GetText(cancellationToken)?.ToString() ?? "";
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Whatever a resource file holds, and however malformed it is, it must not take the generation of the
+        // rest of the project down with it: an exception escaping here is reported by the compiler as a single
+        // CS8785 that names neither the file nor the reason, after which no resource file of the project is
+        // generated at all.
+        try
+        {
+            var generated = codeGenerator.GenerateCode(
+                baseFilename: Path.GetFileName(file.Path).Split('.')[0],
+                content: content,
+                defaultNamespace: project.GetNamespace(file.Path),
+                isAdvanced: true,
+                appType: project.AppType);
+
+            if (generated?.Files.FirstOrDefault() is not { } generatedFile)
+            {
+                return null;
+            }
+
+            return ReswGeneratedFile.Generated(
+                file.Path,
+                hintName,
+                generatedFile.Content,
+                generated.ContainsMacro,
+                generated.ContainsPlural);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            return ReswGeneratedFile.Failed(file.Path, hintName, exception.Message);
+        }
+    }
+
+    private static void EmitGeneratedFile(SourceProductionContext spc, ReswGeneratedFile file)
+    {
+        if (file.Content is null)
+        {
+            spc.ReportDiagnostic(Diagnostic.Create(
+                Diagnostics.ResourceFileNotProcessed,
+                CreateFileLocation(file.SourcePath),
+                Path.GetFileName(file.SourcePath),
+                file.Error));
+
+            return;
+        }
+
+        spc.AddSource(file.HintName, SourceText.From(file.Content, Encoding.UTF8));
+    }
+
+    /// <summary>
+    /// Emits the sources shared by every resource file of the project.
+    /// </summary>
+    private static void EmitSupport(SourceProductionContext spc, ReswSupport support)
+    {
+        if (!support.IsSupported)
+        {
+            return;
+        }
+
+        var assemblyName = Assembly.GetExecutingAssembly().GetName().Name;
+
+        // The support sources are shared by every resource file of the project, so they are emitted once.
+        // Adding the same hint name twice throws, which used to make the generator produce nothing at all for
+        // a project holding more than one .resw that uses macros or plurals.
+        var emitted = new HashSet<string>(StringComparer.Ordinal);
+
+        AddSourceFromResource(
+            spc,
+            emitted,
+            support.AppType == AppType.WindowsAppSDK
+                ? $"{assemblyName}.Templates.ResourceStringProviders.MicrosoftResourceStringProvider.txt"
+                : $"{assemblyName}.Templates.ResourceStringProviders.WindowsResourceStringProvider.txt",
+            "ResourceStringProvider");
+
+        if (support.NeedsMacros)
+        {
+            AddSourceFromResource(spc, emitted, $"{assemblyName}.Templates.Macros.Macros.txt", "Macros");
+        }
+
+        if (!support.NeedsPlurals)
+        {
+            return;
+        }
+
+        AddSourceFromResource(spc, emitted, $"{assemblyName}.Templates.Plurals.IPluralProvider.txt", "IPluralProvider");
+        AddSourceFromResource(spc, emitted, $"{assemblyName}.Templates.Plurals.PluralTypeEnum.txt", "PluralTypeEnum");
+        AddSourceFromResource(spc, emitted, $"{assemblyName}.Templates.Utils.IntExt.txt", "IntExt");
+        AddSourceFromResource(spc, emitted, $"{assemblyName}.Templates.Utils.DoubleExt.txt", "DoubleExt");
+
+        AddLanguageSupport(spc, emitted, support, assemblyName!);
     }
 
     /// <summary>
@@ -295,28 +262,20 @@ public partial class ReswSourceGenerator : IIncrementalGenerator
     }
 
     /// <summary>
-    /// Adds language support sources for pluralization based on the provided languages.
+    /// Adds the plural support of the languages the project holds.
     /// </summary>
-    /// <param name="resourceFilePerLanguage">A resource file of each language the project holds.</param>
-    private static void AddLanguageSupport(SourceProductionContext spc, HashSet<string> emittedSources, Dictionary<string, string> resourceFilePerLanguage, bool useApplicationLanguages, AppType appType)
+    private static void AddLanguageSupport(SourceProductionContext spc, HashSet<string> emittedSources, ReswSupport support, string assemblyName)
     {
-        // The whole plural support is shared by every resource file of the project, so it is built once.
-        if (!emittedSources.Add($"ResourceLoaderExtension{GeneratedCode.FileExtension}"))
-        {
-            return;
-        }
-
         var pluralSelectorCode = "default:\n  return new _ReswPlus_AutoGenerated.Plurals.OtherProvider();\n";
-        var assemblyName = Assembly.GetExecutingAssembly().GetName().Name;
+        var languages = support.Languages.Select(language => language.Name).ToArray();
 
         // The single-form provider backs the default branch of the selector, and the languages that only have
         // that form are mapped to it explicitly, so it is emitted once up front and reused.
         AddSourceFromResource(spc, emittedSources, $"{assemblyName}.Templates.Plurals.OtherProvider.txt", "OtherProvider");
 
-        foreach (var pluralFile in PluralFormsRetriever.RetrievePluralFormsForLanguages(resourceFilePerLanguage.Keys))
+        foreach (var pluralFile in PluralFormsRetriever.RetrievePluralFormsForLanguages(languages))
         {
-            var resourceName = $"{assemblyName}.Templates.Plurals.{pluralFile.Id}Provider.txt";
-            AddSourceFromResource(spc, emittedSources, resourceName, $"{pluralFile.Id}Provider");
+            AddSourceFromResource(spc, emittedSources, $"{assemblyName}.Templates.Plurals.{pluralFile.Id}Provider.txt", $"{pluralFile.Id}Provider");
 
             // Add each language handled by this provider.
             foreach (var lng in pluralFile.Languages)
@@ -329,21 +288,29 @@ public partial class ReswSourceGenerator : IIncrementalGenerator
         // Report the languages that have no rules, so that falling back to a single plural form is a visible
         // choice rather than a silent one. Each one is reported against a resource file of that language,
         // rather than against nothing, so that it has a place to point at and can be configured per file.
-        foreach (var language in PluralFormsRetriever.RetrieveLanguagesWithoutPluralForm(resourceFilePerLanguage.Keys))
+        var filesByLanguage = support.Languages.ToDictionary(language => language.Name, language => language.Path, StringComparer.Ordinal);
+
+        foreach (var language in PluralFormsRetriever.RetrieveLanguagesWithoutPluralForm(languages))
         {
             spc.ReportDiagnostic(Diagnostic.Create(
                 Diagnostics.UnknownPluralLanguage,
-                CreateFileLocation(resourceFilePerLanguage[language]),
+                CreateFileLocation(filesByLanguage[language]),
                 language));
         }
 
         // Build and add the ResourceLoaderExtension with the plural selector injected.
-        var resourceLoaderResourceName = $"{assemblyName}.Templates.Plurals.ResourceLoaderExtension.txt";
-        var resourceLoaderTemplate = ReadAllText(Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceLoaderResourceName));
-        var resourceLoaderCode = resourceLoaderTemplate
+        var hintName = $"ResourceLoaderExtension{GeneratedCode.FileExtension}";
+
+        if (!emittedSources.Add(hintName))
+        {
+            return;
+        }
+
+        var resourceLoaderCode = ReadTemplate($"{assemblyName}.Templates.Plurals.ResourceLoaderExtension.txt")
             .Replace("{{PluralProviderSelector}}", pluralSelectorCode)
-            .Replace("{{PluralLanguageResolver}}", PluralLanguageResolvers.GetResolver(useApplicationLanguages, appType));
-        spc.AddSource($"ResourceLoaderExtension{GeneratedCode.FileExtension}", SourceText.From(GeneratedCode.AddFileHeader(resourceLoaderCode), Encoding.UTF8));
+            .Replace("{{PluralLanguageResolver}}", PluralLanguageResolvers.GetResolver(support.UseApplicationLanguages, support.AppType));
+
+        spc.AddSource(hintName, SourceText.From(GeneratedCode.AddFileHeader(resourceLoaderCode), Encoding.UTF8));
     }
 
     /// <summary>
@@ -359,7 +326,7 @@ public partial class ReswSourceGenerator : IIncrementalGenerator
     }
 
     /// <summary>
-    /// Reads a resource stream and adds its content as a source file, unless it was already added.
+    /// Reads a template and adds its content as a source file, unless it was already added.
     /// </summary>
     /// <param name="spc">The context to add the source to.</param>
     /// <param name="emittedSources">The hint names already emitted for the project.</param>
@@ -368,28 +335,41 @@ public partial class ReswSourceGenerator : IIncrementalGenerator
     private static void AddSourceFromResource(SourceProductionContext spc, HashSet<string> emittedSources, string resourcePath, string typeName)
     {
         var hintName = $"{typeName}{GeneratedCode.FileExtension}";
+
         if (!emittedSources.Add(hintName))
         {
             return;
         }
 
-        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourcePath);
-        if (stream is null)
+        var template = ReadTemplate(resourcePath);
+
+        if (template.Length == 0)
         {
-            // Optionally, report a diagnostic or throw if the resource is missing.
             return;
         }
-        var sourceText = ReadAllText(stream);
-        spc.AddSource(hintName, SourceText.From(GeneratedCode.AddFileHeader(sourceText), Encoding.UTF8));
+
+        spc.AddSource(hintName, SourceText.From(GeneratedCode.AddFileHeader(template), Encoding.UTF8));
     }
 
     /// <summary>
-    /// Reads all text from the provided stream.
+    /// Reads a template out of the embedded resources of this assembly.
     /// </summary>
-    private static string ReadAllText(Stream stream)
+    /// <param name="resourcePath">The path of the embedded resource holding the template.</param>
+    /// <returns>The content of the template, or an empty string when there is no such resource.</returns>
+    private static string ReadTemplate(string resourcePath)
     {
-        _ = stream.Seek(0, SeekOrigin.Begin);
-        using var reader = new StreamReader(stream);
-        return reader.ReadToEnd();
+        return Templates.GetOrAdd(resourcePath, static path =>
+        {
+            using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(path);
+
+            if (stream is null)
+            {
+                return "";
+            }
+
+            using var reader = new StreamReader(stream);
+
+            return reader.ReadToEnd();
+        });
     }
 }

--- a/tests/ReswPlusUnitTests/GeneratorHarness.cs
+++ b/tests/ReswPlusUnitTests/GeneratorHarness.cs
@@ -106,7 +106,7 @@ internal static class ReswGeneratorHarness
             new TestAnalyzerConfigOptionsProvider(options),
             new GeneratorDriverOptions(IncrementalGeneratorOutputKind.None, trackIncrementalGeneratorSteps: true));
 
-        return ReswGeneratorRun.From(driver, compilation);
+        return ReswGeneratorRun.From(driver, compilation, texts);
 
         void Declare(string key, string? value)
         {
@@ -143,11 +143,18 @@ internal sealed class ReswGeneratorRun
 {
     private readonly GeneratorDriver _driver;
     private readonly Compilation _inputCompilation;
+    private readonly ImmutableArray<AdditionalText> _texts;
 
-    private ReswGeneratorRun(GeneratorDriver driver, Compilation inputCompilation, Compilation outputCompilation, ImmutableArray<Diagnostic> diagnostics)
+    private ReswGeneratorRun(
+        GeneratorDriver driver,
+        Compilation inputCompilation,
+        ImmutableArray<AdditionalText> texts,
+        Compilation outputCompilation,
+        ImmutableArray<Diagnostic> diagnostics)
     {
         _driver = driver;
         _inputCompilation = inputCompilation;
+        _texts = texts;
         OutputCompilation = outputCompilation;
         Diagnostics = diagnostics;
     }
@@ -175,11 +182,11 @@ internal sealed class ReswGeneratorRun
     /// </summary>
     public IReadOnlyList<string> DiagnosticIds => [.. Diagnostics.Select(diagnostic => diagnostic.Id)];
 
-    internal static ReswGeneratorRun From(GeneratorDriver driver, Compilation compilation)
+    internal static ReswGeneratorRun From(GeneratorDriver driver, Compilation compilation, ImmutableArray<AdditionalText> texts)
     {
         driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
 
-        return new ReswGeneratorRun(driver, compilation, outputCompilation, diagnostics);
+        return new ReswGeneratorRun(driver, compilation, texts, outputCompilation, diagnostics);
     }
 
     /// <summary>
@@ -188,16 +195,20 @@ internal sealed class ReswGeneratorRun
     /// <param name="files">The files of the project for this run.</param>
     /// <returns>The result of the second run, which remembers what the first one computed.</returns>
     /// <remarks>
-    /// This is how the compiler behaves while a project is edited, and it is the only way to observe what the
-    /// generator recomputes and what it reuses.
+    /// A file whose path and content did not change keeps the very object the previous run saw, which is what
+    /// the compiler does while a project is edited: it hands the generator a new
+    /// <see cref="AdditionalText"/> for the file that changed and the same ones as before for the rest. Handing
+    /// new objects for all of them would make every file look edited and hide what the generator reuses.
     /// </remarks>
     public ReswGeneratorRun RunAgain(IEnumerable<ReswFile> files)
     {
         var texts = files
-            .Select(file => (AdditionalText)new InMemoryAdditionalText(file.Path, file.Content))
+            .Select(file => _texts.FirstOrDefault(text =>
+                text.Path == file.Path && text is InMemoryAdditionalText { } existing && existing.Content == file.Content)
+                ?? new InMemoryAdditionalText(file.Path, file.Content))
             .ToImmutableArray();
 
-        return From(_driver.ReplaceAdditionalTexts(texts), _inputCompilation);
+        return From(_driver.ReplaceAdditionalTexts(texts), _inputCompilation, texts);
     }
 
     /// <summary>
@@ -271,19 +282,34 @@ internal sealed class ReswGeneratorRun
     }
 
     /// <summary>
-    /// Returns the reasons a step of the pipeline was run for, keyed by the name the step is tracked under.
+    /// Returns the reasons the outputs of a tracked step were produced for.
     /// </summary>
+    /// <param name="stepName">The name the step is tracked under.</param>
+    /// <returns>One reason per output the step produced.</returns>
     /// <remarks>
-    /// A step whose inputs didn't change is reported as <see cref="IncrementalStepRunReason.Cached"/> or
+    /// An output whose inputs didn't change is reported as <see cref="IncrementalStepRunReason.Cached"/> or
     /// <see cref="IncrementalStepRunReason.Unchanged"/>, which is what tells a test that the generator reused
     /// what it had rather than recomputing it.
     /// </remarks>
-    public IReadOnlyDictionary<string, IReadOnlyList<IncrementalStepRunReason>> TrackedSteps()
+    public IReadOnlyList<IncrementalStepRunReason> Reasons(string stepName)
     {
-        return _driver.GetRunResult().Results.Single().TrackedSteps.ToDictionary(
-            step => step.Key,
-            step => (IReadOnlyList<IncrementalStepRunReason>)
-                [.. step.Value.SelectMany(run => run.Outputs).Select(output => output.Reason)]);
+        var steps = _driver.GetRunResult().Results.Single().TrackedSteps;
+
+        Assert.True(
+            steps.ContainsKey(stepName),
+            $"No step is tracked under '{stepName}'. The pipeline tracks: " +
+            $"{string.Join(", ", steps.Keys.OrderBy(name => name, StringComparer.Ordinal))}.");
+
+        return [.. steps[stepName].SelectMany(run => run.Outputs).Select(output => output.Reason)];
+    }
+
+    /// <summary>
+    /// Returns how many outputs of a tracked step had to be computed again.
+    /// </summary>
+    /// <param name="stepName">The name the step is tracked under.</param>
+    public int RecomputedCount(string stepName)
+    {
+        return Reasons(stepName).Count(reason => reason is not (IncrementalStepRunReason.Cached or IncrementalStepRunReason.Unchanged));
     }
 
     /// <summary>
@@ -292,21 +318,15 @@ internal sealed class ReswGeneratorRun
     /// <param name="stepName">The name the step is tracked under.</param>
     public void AssertReused(string stepName)
     {
-        var steps = TrackedSteps();
-
-        Assert.True(
-            steps.ContainsKey(stepName),
-            $"No step is tracked under '{stepName}'. The pipeline tracks: " +
-            $"{string.Join(", ", steps.Keys.OrderBy(name => name, StringComparer.Ordinal))}.");
-
-        var recomputed = steps[stepName]
+        var reasons = Reasons(stepName);
+        var recomputed = reasons
             .Where(reason => reason is not (IncrementalStepRunReason.Cached or IncrementalStepRunReason.Unchanged))
             .ToArray();
 
         Assert.True(
             recomputed.Length == 0,
-            $"The step '{stepName}' was expected to be reused, but {recomputed.Length} of its outputs were " +
-            $"recomputed: {string.Join(", ", recomputed)}.");
+            $"The step '{stepName}' was expected to be reused, but {recomputed.Length} of its {reasons.Count} " +
+            $"outputs were recomputed: {string.Join(", ", recomputed)}.");
     }
 }
 
@@ -321,6 +341,11 @@ internal sealed class InMemoryAdditionalText(string path, string content) : Addi
 
     /// <inheritdoc/>
     public override string Path { get; } = path;
+
+    /// <summary>
+    /// Gets the content of the file.
+    /// </summary>
+    public string Content { get; } = content;
 
     /// <inheritdoc/>
     public override SourceText GetText(CancellationToken cancellationToken = default)

--- a/tests/ReswPlusUnitTests/GeneratorIncrementality.cs
+++ b/tests/ReswPlusUnitTests/GeneratorIncrementality.cs
@@ -1,0 +1,182 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace ReswPlusUnitTests;
+
+/// <summary>
+/// Covers what the generator recomputes while a project is edited.
+/// </summary>
+/// <remarks>
+/// The compiler keeps the result of every stage of the pipeline between runs and only reruns the ones whose
+/// inputs changed, so how the stages are split is what decides the cost of a keystroke in the IDE. That cost
+/// is invisible in the output -- a generator that recomputes everything on every keystroke produces exactly
+/// the same code as one that recomputes nothing -- which is why it is asserted here rather than described.
+/// </remarks>
+public class GeneratorIncrementality
+{
+    private const string English = "en-US";
+
+    private static IReadOnlyList<ReswFile> ThreeResources(string firstValue = "First") =>
+    [
+        ReswGeneratorHarness.File(English, ReswTestHelpers.CreateResw(("Greeting", firstValue, null)), baseName: "First"),
+        ReswGeneratorHarness.File(English, ReswTestHelpers.CreateResw(("Farewell", "Second", null)), baseName: "Second"),
+        ReswGeneratorHarness.File(English, ReswTestHelpers.CreateResw(("Question", "Third", null)), baseName: "Third"),
+    ];
+
+    [Fact]
+    public void RunningAgainOverAnUnchangedProjectRecomputesNothing()
+    {
+        var files = ThreeResources();
+        var second = ReswGeneratorHarness.Run(files).RunAgain(files);
+
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Options);
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.CompilationInfo);
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Project);
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Layout);
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Generation);
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Support);
+    }
+
+    /// <summary>
+    /// The whole point of splitting the pipeline: a string edited in one resource file costs the work of that
+    /// file, not the work of the project.
+    /// </summary>
+    [Fact]
+    public void EditingOneResourceOnlyRegeneratesThatResource()
+    {
+        var first = ReswGeneratorHarness.Run(ThreeResources());
+        var second = first.RunAgain(ThreeResources(firstValue: "First, edited"));
+
+        Assert.Equal(1, second.RecomputedCount(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Generation));
+        Assert.Contains("First, edited", second.Source("First.resw"));
+    }
+
+    [Fact]
+    public void EditingAResourceDoesNotMakeTheProjectRegroup()
+    {
+        var first = ReswGeneratorHarness.Run(ThreeResources());
+        var second = first.RunAgain(ThreeResources(firstValue: "First, edited"));
+
+        // The layout is worked out from the paths of the resource files, which an edit does not touch.
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Paths);
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Layout);
+    }
+
+    [Fact]
+    public void EditingAResourceDoesNotMakeThePropertiesOfTheProjectBeReadAgain()
+    {
+        var first = ReswGeneratorHarness.Run(ThreeResources());
+        var second = first.RunAgain(ThreeResources(firstValue: "First, edited"));
+
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Options);
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.CompilationInfo);
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Project);
+    }
+
+    /// <summary>
+    /// The support sources are shared by the whole project, and rebuilding them means rebuilding the plural
+    /// rules of every language it is translated in.
+    /// </summary>
+    [Fact]
+    public void EditingAResourceDoesNotRebuildTheSharedSupport()
+    {
+        var plural = ReswTestHelpers.CreateResw(
+            ("Items_One", "{0} item", "#Format[Plural itemCount]"),
+            ("Items_Other", "{0} items", "#Format[Plural itemCount]"));
+
+        var edited = ReswTestHelpers.CreateResw(
+            ("Items_One", "{0} item, edited", "#Format[Plural itemCount]"),
+            ("Items_Other", "{0} items", "#Format[Plural itemCount]"));
+
+        var first = ReswGeneratorHarness.Run(
+        [
+            ReswGeneratorHarness.File(English, plural),
+            ReswGeneratorHarness.File("ru-RU", plural),
+        ]);
+
+        var second = first.RunAgain(
+        [
+            ReswGeneratorHarness.File(English, edited),
+            ReswGeneratorHarness.File("ru-RU", plural),
+        ]);
+
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Support);
+    }
+
+    [Fact]
+    public void EditingATranslationDoesNotRegenerateAnything()
+    {
+        var english = ReswTestHelpers.CreateResw(("Plain", "A value", null));
+
+        var first = ReswGeneratorHarness.Run(
+        [
+            ReswGeneratorHarness.File(English, english),
+            ReswGeneratorHarness.File("fr-FR", ReswTestHelpers.CreateResw(("Plain", "Une valeur", null))),
+        ],
+        defaultLanguage: English);
+
+        var second = first.RunAgain(
+        [
+            ReswGeneratorHarness.File(English, english),
+            ReswGeneratorHarness.File("fr-FR", ReswTestHelpers.CreateResw(("Plain", "Une autre valeur", null))),
+        ]);
+
+        // Only the file of the default language is generated from, so a translation being edited changes
+        // nothing the generator emits.
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Generation);
+    }
+
+    [Fact]
+    public void TouchingAResourceWithoutChangingWhatItDeclaresCostsNothingDownstream()
+    {
+        var files = ThreeResources();
+
+        // The same resources, in files the compiler hands over as new objects, which is what happens when an
+        // edit is undone or a file is rewritten by a tool.
+        var touched = files
+            .Select(file => new ReswFile(file.Path, file.Content + "\r\n"))
+            .ToArray();
+
+        var first = ReswGeneratorHarness.Run(files);
+        var second = first.RunAgain(touched);
+
+        // The files are read and generated again, but what comes out is the same, so nothing below the
+        // generation stage runs and nothing is emitted again.
+        Assert.Equal(0, second.RecomputedCount(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Generation));
+        second.AssertReused(ReswPlus.SourceGenerator.Pipeline.TrackingNames.Support);
+
+        Assert.Equal(
+            first.Sources.OrderBy(source => source.Key, System.StringComparer.Ordinal),
+            second.Sources.OrderBy(source => source.Key, System.StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void AddingAResourceGeneratesItAndLeavesTheOutputOfTheOthersAlone()
+    {
+        var first = ReswGeneratorHarness.Run(ThreeResources());
+
+        var second = first.RunAgain(
+        [
+            .. ThreeResources(),
+            ReswGeneratorHarness.File(English, ReswTestHelpers.CreateResw(("Extra", "Fourth", null)), baseName: "Fourth"),
+        ]);
+
+        Assert.Contains("Fourth", second.Source("Fourth.resw"));
+        Assert.Equal(4, second.Sources.Keys.Count(name => name.Contains(".resw")));
+        second.AssertCompiles();
+    }
+
+    [Fact]
+    public void TheTemplatesAreOnlyReadOnceForTheWholeProject()
+    {
+        // Reading a template decodes an embedded resource, and the same handful of templates back every
+        // project the generator is loaded for, so they are decoded once and kept.
+        var first = ReswGeneratorHarness.Run(ThreeResources());
+        var second = first.RunAgain(ThreeResources(firstValue: "First, edited"));
+
+        Assert.Equal(
+            first.Source("ResourceStringProvider"),
+            second.Source("ResourceStringProvider"));
+    }
+}


### PR DESCRIPTION
Splits the incremental pipeline so that editing one resource file costs the work of that file.

Builds on #56 and #57, both merged - this now targets `main` and shows only its own changes.

## Why

Every `.resw` file was collected into a single node, combined with the options and the compilation, and handed to one `RegisterSourceOutput` that did all the work. Nothing was keyed on an individual file, so editing one string re-read, re-parsed and regenerated **every** `.resw` in the project, regrouped them all by language, and rebuilt the plural support of every language it is translated in â€” on every keystroke, in the IDE.

The care already taken to project the `Compilation` down to an equatable `CompilationInfo` bought nothing, because everything below it was invalidated anyway.

## What

The work is split along the lines it actually depends on:

| Stage | Depends on | Reruns when |
|---|---|---|
| `Options` | MSBuild properties | a property changes |
| `CompilationInfo` | references, assembly name | a reference changes |
| `Project` | the two above | either changes |
| `Layout` | the **paths** of the `.resw` files | a file is added, removed or renamed |
| `Generation` | one resource file | *that* file changes |
| `Support` | flags aggregated from generation | a project starts or stops using macros/plurals |

Deriving the layout from paths alone is what keeps an edit from making the project regroup. `ReswBuildOptions`, `ReswProject`, `ReswLayout`, `ReswGeneratedFile` and `ReswSupport` are equatable values, backed by an `EquatableArray<T>` â€” `ImmutableArray<T>` compares by reference, which would recompute every stage below it on every run.

Every stage is named with `WithTrackingName`, so what the generator reuses can be **asserted rather than described**: a generator that recomputes everything on every keystroke emits exactly the same code as one that recomputes nothing, which is why this went unnoticed.

Also: the embedded templates are decoded once instead of read off a manifest stream on every run, and resource files are looked up by path in a dictionary rather than by scanning the whole list for each of them.

## Testing

375 tests pass, including a new `GeneratorIncrementality` suite. Editing one of three resources now regenerates exactly one of them; an unchanged rerun recomputes nothing at all.

