### PR TITLE
Make the Native AOT sample run, and document what it cannot do

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _**Now available as a Source Generator!**_
   - Typed and named parameters, literal strings, string references, and macros.
 - **Pluralization support** for *196 languages*, including handling empty states when the item count is zero.
 - **Variant support** for managing multiple versions of a string.
-- **Generation of a markup extension** for accessing strings with **compile-time verification**.
+- **Generation of a markup extension** for accessing strings with **compile-time verification**. *(Not usable when the app is compiled with Native AOT — see [Native AOT](#-native-aot).)*
 
 ## ✅ Feature Comparison
 
@@ -47,6 +47,22 @@ ReswPlus recognizes a UWP project by the `Windows.Foundation.UniversalApiContrac
 ```
 
 Without it, such a project is reported as `RESWP0005` and no code is generated for it. The `samples/UWP` folder has one sample of each kind: `ReswPlusUWPSample` built with .NET Native, and `ReswPlusNativeAotUwpSample` built on modern .NET with Native AOT.
+
+## ⚡ Native AOT
+
+Everything ReswPlus generates works when the app is compiled with Native AOT, **except the markup extension**:
+
+```xml
+<!-- Works with Native AOT: resolved while the app is compiled -->
+<TextBlock Text="{x:Bind strings:Resources.WelcomeTitle}" />
+
+<!-- Does NOT work with Native AOT: created by the XAML parser while the page is read -->
+<TextBlock Text="{strings:Resources Key=WelcomeTitle}" />
+```
+
+A page that uses the markup extension fails to load, with `Markup extension could not provide value`. Use `x:Bind` instead; it takes a converter the same way, and it is checked while the app is compiled rather than when the page is shown.
+
+This is not something a trimming directive can keep: preserving the generated types with `rd.xml` or a trimmer root does not change it.
 
 ## 🔧 Features
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -3,6 +3,21 @@
 Because ReswPlus uses [MarkupExtension](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.markup.markupextension), the minimum version supported is 	
 Windows 10 Fall Creators Update (1709).
 
+## Can I use the markup extension in an app compiled with Native AOT?
+
+No. A markup extension is created by the XAML parser while it reads a page, and a UWP app compiled with
+Native AOT cannot create it, so a page that uses one fails to load with `Markup extension could not provide
+value`. Preserving the generated types with `rd.xml` or a trimmer root does not change it.
+
+Use `x:Bind` instead, which is resolved while the app is compiled and works either way:
+
+```xml
+<TextBlock Text="{x:Bind strings:Resources.WelcomeTitle}" />
+```
+
+It takes a converter the same way the markup extension does. Everything else ReswPlus generates works with
+Native AOT.
+
 ## Does it support VB or C++?
 
 VB support is currently under development. C++/CX and C++/WinRT support are planned for a future update.

--- a/samples/UWP/ReswPlusNativeAotUwpSample/Package.appxmanifest
+++ b/samples/UWP/ReswPlusNativeAotUwpSample/Package.appxmanifest
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
@@ -19,7 +19,7 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26100.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26100.0" />
   </Dependencies>
 
   <Resources>

--- a/samples/UWP/ReswPlusNativeAotUwpSample/Properties/PublishProfiles/win-arm64.pubxml
+++ b/samples/UWP/ReswPlusNativeAotUwpSample/Properties/PublishProfiles/win-arm64.pubxml
@@ -5,6 +5,6 @@
     <Platform>arm64</Platform>
     <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
-    <SelfContained>true</SelfContained>
+    <SelfContained Condition="'$(PublishAot)' == 'true'">true</SelfContained>
   </PropertyGroup>
 </Project>

--- a/samples/UWP/ReswPlusNativeAotUwpSample/Properties/PublishProfiles/win-x64.pubxml
+++ b/samples/UWP/ReswPlusNativeAotUwpSample/Properties/PublishProfiles/win-x64.pubxml
@@ -5,6 +5,6 @@
     <Platform>x64</Platform>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
-    <SelfContained>true</SelfContained>
+    <SelfContained Condition="'$(PublishAot)' == 'true'">true</SelfContained>
   </PropertyGroup>
 </Project>

--- a/samples/UWP/ReswPlusNativeAotUwpSample/Properties/PublishProfiles/win-x86.pubxml
+++ b/samples/UWP/ReswPlusNativeAotUwpSample/Properties/PublishProfiles/win-x86.pubxml
@@ -5,6 +5,6 @@
     <Platform>x86</Platform>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
-    <SelfContained>true</SelfContained>
+    <SelfContained Condition="'$(PublishAot)' == 'true'">true</SelfContained>
   </PropertyGroup>
 </Project>

--- a/samples/UWP/ReswPlusNativeAotUwpSample/ReswPlusNativeAotUwpSample.csproj
+++ b/samples/UWP/ReswPlusNativeAotUwpSample/ReswPlusNativeAotUwpSample.csproj
@@ -17,6 +17,11 @@
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <!--
+      Naming the publish profile here is what gives an ordinary build a runtime identifier to resolve against,
+      which is what the Store's own UWP app does. It makes the build lay down a self-contained app.
+    -->
+    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
+    <!--
       This is what makes the project a UWP project on modern .NET. It is also the only thing that tells
       ReswPlus what kind of app this is: unlike a UWP project built with .NET Native, this one carries no
       'Windows.Foundation.UniversalApiContract' reference for the generator to recognize it by.
@@ -32,21 +37,28 @@
     <AppxSymbolPackageEnabled>False</AppxSymbolPackageEnabled>
     <GenerateTestArtifacts>False</GenerateTestArtifacts>
     <AppxBundle>Never</AppxBundle>
+
+    <!--
+      Native AOT replaces the .NET Native toolchain a UWP app used to be compiled with. Asking for it is safe
+      on every build: it only actually runs while the build produces an MSIX package, so an ordinary build
+      stays a normal managed build and stays debuggable. This is what the Store's UWP app does.
+    -->
+    <PublishAot>true</PublishAot>
+
+    <!--
+      Set this to package on build, which is what turns Native AOT on. In Visual Studio it is the
+      'NativeAOT Build' checkbox in the project properties, which writes 'GenerateAppxPackageOnBuild' into
+      the .user file. It is taken through a name of our own because setting 'GenerateAppxPackageOnBuild'
+      globally makes the libraries of the solution try to package themselves too.
+
+      Use it with the Release configuration: packaging a Debug build produces a package with no runtime in it.
+
+        msbuild /t:Rebuild /p:Configuration=Release /p:Platform=x64 /p:ReswPlusGenerateAppxPackageOnBuild=true
+    -->
+    <GenerateAppxPackageOnBuild Condition="'$(ReswPlusGenerateAppxPackageOnBuild)' == 'true'">true</GenerateAppxPackageOnBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <!--
-      Native AOT is what replaces the .NET Native toolchain a UWP app used to be compiled with. It is only
-      asked for while publishing: turning it on for an ordinary build produces an app that throws inside the
-      XAML framework before its first window. '_IsPublishing' is set by the SDK for the whole publish,
-      including the restore it runs, which is when the AOT compiler has to be brought in.
-
-      Publish one architecture at a time, from a developer command prompt for that architecture, because the
-      AOT link step needs the matching MSVC linker:
-
-        msbuild /t:Restore;Publish /p:Configuration=Release /p:PublishProfile=win-x64 /p:_IsPublishing=true
-    -->
-    <PublishAot Condition="'$(_IsPublishing)' == 'true'">true</PublishAot>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
   </PropertyGroup>
 

--- a/samples/UWP/ReswPlusNativeAotUwpSample/ReswPlusNativeAotUwpSample.csproj
+++ b/samples/UWP/ReswPlusNativeAotUwpSample/ReswPlusNativeAotUwpSample.csproj
@@ -76,6 +76,17 @@
 
   <ItemGroup>
     <!--
+      The generated markup extension takes its key as an enumeration, and XAML converts the name written in
+      the markup into that enumeration at runtime, which needs the names of the enumeration to still be
+      there. Trimming is free to drop them, so the assemblies holding generated resource types are rooted.
+      The .NET Native sample keeps them the same way, through its runtime directives file.
+    -->
+    <TrimmerRootAssembly Include="ReswPlusNativeAotUwpSample" />
+    <TrimmerRootAssembly Include="ReswPlusNativeAotUwpSampleExternalLibrary" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
       The generator that emits the native export above ships in CsWinRT, and the one bundled with the SDK
       produces code that doesn't compile for this project. Referencing the package directly takes a version
       whose generator works, and brings with it the target that produces the small stub executable that sits

--- a/samples/UWP/ReswPlusNativeAotUwpSample/ReswPlusNativeAotUwpSample.csproj
+++ b/samples/UWP/ReswPlusNativeAotUwpSample/ReswPlusNativeAotUwpSample.csproj
@@ -46,6 +46,18 @@
     <PublishAot>true</PublishAot>
 
     <!--
+      An app doesn't export the native 'DllGetActivationFactory' on its own, because that is only turned on
+      for libraries by default. UWP activates through it, so an AOT compiled app that doesn't export it
+      cannot be started and faults inside the XAML framework. This exports it, and forwards activation to
+      the referenced WinRT components, so one binary implements the app and its components. The Store's own
+      UWP app does the same.
+    -->
+    <CsWinRTMergeReferencedActivationFactories>true</CsWinRTMergeReferencedActivationFactories>
+
+    <!-- The native export above is generated as unsafe code. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!--
       Set this to package on build, which is what turns Native AOT on. In Visual Studio it is the
       'NativeAOT Build' checkbox in the project properties, which writes 'GenerateAppxPackageOnBuild' into
       the .user file. It is taken through a name of our own because setting 'GenerateAppxPackageOnBuild'
@@ -61,6 +73,16 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      The generator that emits the native export above ships in CsWinRT, and the one bundled with the SDK
+      produces code that doesn't compile for this project. Referencing the package directly takes a version
+      whose generator works, and brings with it the target that produces the small stub executable that sits
+      beside the native binary. The Store references it for the same reason.
+    -->
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.3.1" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)' != 'true' and '$(EnableMsixTooling)' == 'true'">
     <ProjectCapability Include="Msix" />

--- a/samples/UWP/ReswPlusUWPSample.Shared/Pages/StronglyTypedSamplePage.xaml
+++ b/samples/UWP/ReswPlusUWPSample.Shared/Pages/StronglyTypedSamplePage.xaml
@@ -98,8 +98,9 @@
                 <TextBlock Style="{StaticResource ResultLabelTextBlockStyle}" Text="Result:" />
 
                 <StackPanel Style="{StaticResource ResultPanelStyle}">
-                    <TextBlock Text="{strings:Resources Key=WelcomeTitle}" />
-                    <Button Content="{strings:Resources Key=WelcomeTitle}" ToolTipService.ToolTip="{strings:Resources Key=ThisIsATooltip}" />
+                    <TextBlock
+                        Style="{StaticResource SectionDescriptionTextBlockStyle}"
+                        Text="Not shown here. A markup extension is created by the XAML parser while it reads the page, and a UWP app compiled with Native AOT cannot create it, so a page that uses one fails to load. Both samples share these pages, so the markup extension is left out of them and x:Bind is used instead, which is resolved while the app is compiled and works either way." />
                 </StackPanel>
             </StackPanel>
 
@@ -113,7 +114,9 @@
                 <TextBlock Style="{StaticResource ResultLabelTextBlockStyle}" Text="Result:" />
 
                 <StackPanel Style="{StaticResource ResultPanelStyle}">
-                    <TextBlock Text="{strings:Resources Key=WelcomeTitle, Converter={StaticResource ToUpperCaseConverter}}" />
+                    <TextBlock
+                        Style="{StaticResource SectionDescriptionTextBlockStyle}"
+                        Text="Not shown here either, for the same reason. A converter can be applied to x:Bind in the same way, which the section above does." />
                 </StackPanel>
             </StackPanel>
 
@@ -121,7 +124,7 @@
                 <TextBlock Style="{StaticResource TitleTextBlockStyle}" Text="Use resources from another assembly" />
                 <TextBlock Style="{StaticResource LabelTextBlockStyle}" Text="XAML usage:" />
                 <StackPanel Style="{StaticResource CodePanelStyle}">
-                    <TextBlock Style="{StaticResource DescriptionTextBlockStyle}" Text="&#x3C;TextBlock Text=&#x22;{strings:Resources Key=WelcomeTitle, Converter={StaticResource ToUpperCaseConverter}}&#x22; /&#x3E;" />
+                    <TextBlock Style="{StaticResource DescriptionTextBlockStyle}" Text="&#x3C;TextBlock Text=&#x22;{x:Bind externalStrings:Resources.ExternalString}&#x22; /&#x3E;" />
                 </StackPanel>
                 <TextBlock Style="{StaticResource ResultLabelTextBlockStyle}" Text="Result:" />
 

--- a/src/ReswPlus.SourceGenerator/CodeGenerators/CsharpCodeGenerator.cs
+++ b/src/ReswPlus.SourceGenerator/CodeGenerators/CsharpCodeGenerator.cs
@@ -59,6 +59,17 @@ namespace ReswPlus.SourceGenerator.CodeGenerators;
 internal sealed class CSharpCodeGenerator : ICodeGenerator
 {
     /// <summary>
+    /// The name of the generated method mapping a member of the key enumeration to the name of its resource.
+    /// </summary>
+    /// <remarks>
+    /// The name of a resource is not read off the enumeration with <c>ToString</c>, because the names of an
+    /// enumeration are metadata that trimming and Native AOT are free to drop: the call then returns the
+    /// numeric value of the member, every lookup misses, and the markup extension fails to provide a value.
+    /// Emitting the names as literals keeps them out of the reach of the trimmer, and is faster besides.
+    /// </remarks>
+    private const string KeyNameMethod = "GetKeyName";
+
+    /// <summary>
     /// The text used for the <c>&lt;returns&gt;</c> element of the generated lookup members.
     /// </summary>
     private const string LocalizedStringReturns = "The localized string for the current UI culture.";
@@ -715,6 +726,50 @@ internal sealed class CSharpCodeGenerator : ICodeGenerator
     }
 
     /// <summary>
+    /// Creates the method mapping a member of the key enumeration to the name of the resource it identifies.
+    /// </summary>
+    /// <param name="keys">The keys of the resources the markup extension can look up.</param>
+    /// <returns>The declaration of the method.</returns>
+    /// <remarks>
+    /// The names are emitted as literals rather than read off the enumeration at runtime, so that they survive
+    /// trimming and Native AOT. See <see cref="KeyNameMethod"/>.
+    /// </remarks>
+    private static MethodDeclarationSyntax CreateKeyNameMethod(IEnumerable<string> keys)
+    {
+        var sections = keys.Select(key =>
+            SwitchSection()
+                .WithLabels(SingletonList<SwitchLabelSyntax>(
+                    CaseSwitchLabel(
+                        MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName("KeyEnum"),
+                            MemberName(key)))))
+                .WithStatements(SingletonList<StatementSyntax>(
+                    ReturnStatement(
+                        LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(key))))));
+
+        var defaultSection = SwitchSection()
+            .WithLabels(SingletonList<SwitchLabelSyntax>(DefaultSwitchLabel()))
+            .WithStatements(SingletonList<StatementSyntax>(
+                ReturnStatement(
+                    LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(string.Empty)))));
+
+        return MethodDeclaration(PredefinedType(Token(SyntaxKind.StringKeyword)), KeyNameMethod)
+            .WithModifiers(TokenList(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.StaticKeyword)))
+            .WithParameterList(
+                ParameterList(
+                    SingletonSeparatedList(
+                        Parameter(Identifier("key")).WithType(ParseTypeName("KeyEnum")))))
+            .WithLeadingTrivia(CreateDocumentation(
+                "Returns the name of the resource a key identifies.",
+                "The name of the resource, or an empty string when the key identifies none.",
+                ("key", "The key to return the name of.")))
+            .WithBody(Block(
+                SwitchStatement(IdentifierName("key"))
+                    .WithSections(List(sections.Append(defaultSection)))));
+    }
+
+    /// <summary>
     /// Creates a markup extension class that can be used in XAML for resource lookup.
     /// This class includes an embedded KeyEnum, a static resource provider field,
     /// a static constructor, properties for Key, Converter, ConverterParameter, and
@@ -853,13 +908,11 @@ internal sealed class CSharpCodeGenerator : ICodeGenerator
                                         ArgumentList(
                                             SingletonSeparatedList(
                                                 Argument(
-                                                    InvocationExpression(
-                                                        MemberAccessExpression(
-                                                            SyntaxKind.SimpleMemberAccessExpression,
-                                                            IdentifierName("Key"),
-                                                            IdentifierName("ToString")
-                                                        )
-                                                    )
+                                                    InvocationExpression(IdentifierName(KeyNameMethod))
+                                                    .WithArgumentList(
+                                                        ArgumentList(
+                                                            SingletonSeparatedList(
+                                                                Argument(IdentifierName("Key")))))
                                                 )
                                             )
                                         )
@@ -917,6 +970,7 @@ internal sealed class CSharpCodeGenerator : ICodeGenerator
             ))
             .AddMembers(
                 keyEnum,
+                CreateKeyNameMethod(keys),
                 resourceField,
                 staticCtor,
                 // Create the Key property.

--- a/tests/ReswPlusUnitTests/MarkupExtensionKeys.cs
+++ b/tests/ReswPlusUnitTests/MarkupExtensionKeys.cs
@@ -1,0 +1,65 @@
+using Xunit;
+
+namespace ReswPlusUnitTests;
+
+/// <summary>
+/// Covers the markup extension surviving trimming and Native AOT.
+/// </summary>
+/// <remarks>
+/// The markup extension looks a resource up by the name of the key it is given. Reading that name off the
+/// generated enumeration with <c>ToString</c> only works while the names of the enumeration are still there,
+/// and they are metadata that trimming and Native AOT are free to drop: the call then returns the numeric
+/// value of the member, every lookup misses, and XAML fails with "Markup extension could not provide value"
+/// at the point the page is created. Emitting the names as literals keeps them out of the trimmer's reach.
+/// </remarks>
+public class MarkupExtensionKeys
+{
+    private static string Generated => ReswTestHelpers.GenerateCode(
+        ReswTestHelpers.CreateResw(
+            ("Title", "A title", null),
+            ("Greeting", "Hello {0}", "#Format[String name]")));
+
+    [Fact]
+    public void TheResourceNameIsNotReadOffTheEnumerationAtRuntime()
+    {
+        Assert.DoesNotContain("Key.ToString()", Generated);
+    }
+
+    [Theory]
+    [InlineData("Title")]
+    [InlineData("Greeting")]
+    public void EveryKeyIsMappedToItsResourceNameAsALiteral(string key)
+    {
+        var generated = Generated;
+
+        Assert.Contains($"case KeyEnum.{key}:", generated);
+        Assert.Contains($"return \"{key}\";", generated);
+    }
+
+    [Fact]
+    public void AKeyThatIdentifiesNoResourceReadsAsAnEmptyName()
+    {
+        // '_Undefined' is the member the enumeration starts with, and it names no resource.
+        Assert.Contains("default:", Generated);
+        Assert.Contains("return \"\";", Generated);
+    }
+
+    [Fact]
+    public void TheMarkupExtensionLooksResourcesUpThroughTheGeneratedNames()
+    {
+        Assert.Contains("GetString(GetKeyName(Key))", Generated.Replace(" ", ""));
+    }
+
+    [Fact]
+    public void TheGeneratedCodeStillCompiles()
+    {
+        var run = ReswGeneratorHarness.Run(
+        [
+            ReswGeneratorHarness.File("en-US", ReswTestHelpers.CreateResw(
+                ("Title", "A title", null),
+                ("class", "A keyword named resource", null))),
+        ]);
+
+        run.AssertCompiles();
+    }
+}


### PR DESCRIPTION
Makes the Native AOT UWP sample actually run, and documents the one ReswPlus feature that Native AOT cannot support.

Follows #60, which added the sample. It built, but it did not start.

## The bug

A page using the generated markup extension fails to load under Native AOT:

```
XamlParseException: Markup extension could not provide value
   at XamlTypeInfoProvider.Activate_23_StronglyTypedSamplePage()
```

Proven by bisection rather than inference — delete the three `{strings:Resources Key=…}` lines and the AOT app runs; put them back and it dies. The `x:Bind strings:Resources.WelcomeTitle` lines on that *same page* stayed in throughout and work, because `x:Bind` is resolved while the app is compiled, into the page's own generated code. A markup extension is created by the XAML parser while it reads the page, and a UWP app compiled with Native AOT cannot create it.

**This is not something a trimming directive can keep.** Both mechanisms were tried and measured:

| Attempt | Result |
| --- | --- |
| `TrimmerRootAssembly` on both generated assemblies | no change |
| `rd.xml` runtime directives (ILC does honour these) | metadata demonstrably preserved — native binary grew 5.14 → 6.73 MB — still fails |
| Hand-written `partial` so the XAML compiler sees the type | `XamlTypeInfo.g.cs` gained `ResourcesExtension` *and* its nested `KeyEnum` — still fails |

Also ruled out with evidence: package identity, `resources.pri` (dumped it — app *and* external-library maps present), `Windows.Universal` vs `Windows.Desktop`, `EntryPoint`, and `deps.json`.

## What this changes

**The samples.** Both UWP samples build the same shared pages, so the two live markup-extension usages are gone and `x:Bind` is used instead. Where the strings used to appear, the result panel now explains why — a reader meets the explanation exactly where they'd look for the feature. The code samples still *show* the markup-extension syntax; only the live bindings are gone.

**The docs.** A ⚡ Native AOT section in the README with a works/doesn't-work snippet, a caveat on the feature bullet at the top, and an FAQ entry beside the existing MarkupExtension question. All three say the part that costs people time: a trimming directive will not save it.

**A real AOT bug in the generator, fixed.** The markup extension read the resource name with `Key.ToString()` on the generated enum. The names of an enum are metadata that trimming and Native AOT *are* free to drop — the call then returns the numeric value, and every lookup silently misses. The names are now emitted as literals through a generated `GetKeyName` switch: trim-proof, and faster. Covered by new tests.

**The packaging shape the Store uses.** Taken from `SFC.Client.SFUI`'s `WinStore2.csproj` so the sample produces a genuine Native AOT package:

- `PublishAot` set unconditionally — it only takes effect when the build produces an MSIX, so an ordinary build stays a normal managed build and stays debuggable
- `GenerateAppxPackageOnBuild` behind our own opt-in, because setting it globally makes every library in the solution try to package itself (the Store hit the same thing)
- `CsWinRTMergeReferencedActivationFactories`, which is what makes an *application* export `DllGetActivationFactory` at all — it is only enabled for libraries by default
- an explicit `Microsoft.Windows.CsWinRT` reference, because the generator bundled with the SDK emits code that does not compile (`CS0103: 'obj' does not exist`); the Store references it for the same reason
- `PublishProfile` named in the project, so an ordinary build resolves a runtime identifier and lays down an app it can actually run

The package now matches the Store's own validation table: a 5.22 MB native `.dll` exporting `DllGetActivationFactory` and `DllCanUnloadNow`, a 20 KB stub `.exe`, and no runtime beside it.

## Testing

- **393 unit tests pass**; whole solution builds the way CI does.
- **The Native AOT app was packaged, installed and driven.** The page that used to crash it now loads, `x:Bind` renders the generated strings, the external-library resource resolves, and both notes display.
- **A plain Release build also still runs** — the F5 path is not sacrificed for the packaged one.

## Note for review

The markup-extension usages were removed from the **shared** pages, so the .NET Native sample loses its live demo too, even though it works there. That is the consequence of both samples building the same pages. Keeping it demonstrated for .NET Native only would mean splitting that page per sample — worth doing if the demo matters more than the shared sources.
