### PR TITLE
Stop a malformed resource file from hanging the build

### DIFF
--- a/src/ReswPlus.Shared/ResourceParser/FormatTag.cs
+++ b/src/ReswPlus.Shared/ResourceParser/FormatTag.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -126,7 +127,28 @@ public sealed class FormatTag
         {"Decimal", new FormatTagParameterTypeInfo(ParameterType.Decimal, true)}
     };
 
-    private static readonly Regex RegexNamedParameters = new("^(?:(?:\"(?<literalString>(?:\\\\.|[^\\\"])*)\")|(?:(?<localizationRef>\\w+)\\(\\))|(?:(?<quantifier>Plural\\s+)?(?<type>\\w+)\\s*(?<name>\\w+)?))$");
+    /// <summary>
+    /// How long a match is allowed to take before it is abandoned.
+    /// </summary>
+    /// <remarks>
+    /// The expressions here are written not to backtrack pathologically, and this is the net under them: a
+    /// resource file is written by hand, and a parser that never returns takes the whole build with it.
+    /// </remarks>
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(5);
+    /// <summary>
+    /// Matches one parameter of a <c>#Format</c> tag.
+    /// </summary>
+    /// <remarks>
+    /// The run inside a quoted literal is written so that it can only be read one way: characters that are
+    /// neither a quote nor a backslash, then any number of escapes each followed by more of the same. Written
+    /// as <c>(?:\\.|[^"])*</c> instead, a backslash could be taken either on its own or as the start of an
+    /// escape, and the expression has to try every combination of a run of them before it can fail — which is
+    /// exponential, and happens on an unterminated literal, an ordinary typo.
+    /// </remarks>
+    private static readonly Regex RegexNamedParameters = new(
+        @"^(?:(?:""(?<literalString>[^""\\]*(?:\\.[^""\\]*)*)"")|(?:(?<localizationRef>\w+)\(\))|(?:(?<quantifier>Plural\s+)?(?<type>\w+)\s*(?<name>\w+)?))$",
+        RegexOptions.None,
+        RegexTimeout);
 
     public static FunctionFormatTagParametersInfo? ParseParameters(string key, IEnumerable<string> types, IEnumerable<ReswItem> basicLocalizedItems, string resourceFilename, IErrorLogger? logger)
     {
@@ -240,19 +262,94 @@ public sealed class FormatTag
     }
 
     /// <summary>
-    /// Extract parameters but ignore \" and , in literal strings.
+    /// Splits the parameters of a tag, leaving the commas and quotes inside a quoted literal alone.
     /// </summary>
+    /// <param name="source">The text between the brackets of the tag.</param>
+    /// <returns>The parameters, or nothing at all when the text does not read as a list of them.</returns>
+    /// <remarks>
+    /// Read by hand rather than with an expression. The text comes from the comment of a resource, which is
+    /// written by hand and read on every keystroke, and an expression over it has to be able to conclude that
+    /// an unterminated literal is unterminated without trying every way of reading the escapes inside it
+    /// first. Reading it once, left to right, takes the length of the text however malformed it is.
+    /// </remarks>
     public static IEnumerable<string> SplitParameters(string source)
     {
         source = source.Trim();
-        var regex = new Regex(@"(?:(?<param>(?:\x22(?:\\.|[^\x22])*\x22)|(?:\w[^\x22,]*?))\s*(?:,|$)\s*)+");
-        var match = regex.Match(source);
-        if (match.Success && match.Length == source.Length)
+
+        var parameters = new List<string>();
+        var index = 0;
+
+        while (index < source.Length)
         {
-            foreach (Capture capture in match.Groups["param"].Captures)
+            var start = index;
+
+            if (source[index] == '"')
             {
-                yield return capture.Value;
+                index++;
+
+                while (index < source.Length && source[index] != '"')
+                {
+                    // A backslash takes the character after it with it, so that an escaped quote does not end
+                    // the literal.
+                    index += source[index] == '\\' ? 2 : 1;
+                }
+
+                if (index >= source.Length)
+                {
+                    // The literal is never closed.
+                    return [];
+                }
+
+                index++;
+            }
+            else if (IsParameterStart(source[index]))
+            {
+                while (index < source.Length && source[index] != ',' && source[index] != '"')
+                {
+                    index++;
+                }
+            }
+            else
+            {
+                return [];
+            }
+
+            parameters.Add(source.Substring(start, index - start).TrimEnd());
+
+            index = SkipWhitespace(source, index);
+
+            if (index >= source.Length)
+            {
+                break;
+            }
+
+            if (source[index] != ',')
+            {
+                return [];
+            }
+
+            index = SkipWhitespace(source, index + 1);
+
+            if (index >= source.Length)
+            {
+                // A trailing comma announces a parameter that never comes.
+                return [];
             }
         }
+
+        return parameters;
+    }
+
+    private static bool IsParameterStart(char character) =>
+        char.IsLetterOrDigit(character) || character == '_';
+
+    private static int SkipWhitespace(string source, int index)
+    {
+        while (index < source.Length && char.IsWhiteSpace(source[index]))
+        {
+            index++;
+        }
+
+        return index;
     }
 }

--- a/src/ReswPlus.Shared/ResourceParser/ReswParser.cs
+++ b/src/ReswPlus.Shared/ResourceParser/ReswParser.cs
@@ -1,15 +1,39 @@
+using System.IO;
 using System.Xml;
 
 namespace ReswPlus.Core.ResourceParser;
 
 public sealed class ReswParser
 {
+    /// <summary>
+    /// Reads the resources out of the content of a <c>.resw</c> file.
+    /// </summary>
+    /// <param name="content">The content of the file.</param>
+    /// <returns>The resources it declares.</returns>
+    /// <exception cref="XmlException">The content is not well formed, or declares a document type.</exception>
+    /// <remarks>
+    /// A resource file is written by hand and read on every keystroke, so it is read with document types
+    /// refused and nothing resolved from outside it. A document type is what lets a few hundred bytes expand
+    /// into gigabytes through nested entities, and an external reference is what lets a file reach for
+    /// something that is not part of the project at all. Neither has any business in a resource file.
+    /// </remarks>
     public static ReswInfo Parse(string content)
     {
         var res = new ReswInfo();
 
-        var xml = new XmlDocument();
-        xml.LoadXml(content);
+        var settings = new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+        };
+
+        var xml = new XmlDocument { XmlResolver = null };
+
+        using (var text = new StringReader(content))
+        using (var reader = XmlReader.Create(text, settings))
+        {
+            xml.Load(reader);
+        }
 
         var nodes = xml.DocumentElement?.SelectNodes("//data");
         if (nodes is null)

--- a/src/ReswPlus.SourceGenerator/ClassGenerators/ReswClassGenerator.cs
+++ b/src/ReswPlus.SourceGenerator/ClassGenerators/ReswClassGenerator.cs
@@ -31,10 +31,28 @@ public sealed class ReswClassGenerator
 
     static ReswClassGenerator()
     {
-        // Matches either #Format[...] or #FormatNet[...] including escaped quotes inside.
+        // Matches either #Format[...] or #FormatNet[...], where the content may hold quoted literals that
+        // escape a quote with a backslash.
+        //
+        // The run inside a literal is written so that it can only be read one way: characters that are
+        // neither a quote nor a backslash, then any number of escapes each followed by more of the same. Read
+        // as "anything up to a quote", a backslash could be taken either on its own or as the start of an
+        // escape, and the expression has to try every combination of a run of them before it can fail — which
+        // is exponential, and this runs over the comment of a resource on every keystroke.
         _regexStringFormat = new Regex(
-            $@"(?<tag>{TagFormat}|{TagFormatDotNet})\[(?<formats>(?:""(?:""|[^""])*""|[^\\""])+)\]");
+            $@"(?<tag>{TagFormat}|{TagFormatDotNet})\[(?<formats>(?:""[^""\\]*(?:\\.[^""\\]*)*""|[^\\""])+)\]",
+            RegexOptions.None,
+            RegexTimeout);
     }
+
+    /// <summary>
+    /// How long a match is allowed to take before it is abandoned.
+    /// </summary>
+    /// <remarks>
+    /// The expressions here are written not to backtrack pathologically, and this is the net under them: a
+    /// resource file is written by hand, and a generator that never returns takes the whole build with it.
+    /// </remarks>
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(5);
 
     private ReswClassGenerator(ResourceFileInfo resourceInfo, ICodeGenerator generator, IErrorLogger? logger)
     {

--- a/tests/ReswPlusUnitTests/MalformedResourceFiles.cs
+++ b/tests/ReswPlusUnitTests/MalformedResourceFiles.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml;
+using ReswPlus.Core.ResourceParser;
+using Xunit;
+
+namespace ReswPlusUnitTests;
+
+/// <summary>
+/// Covers a resource file that is malformed rather than merely wrong.
+/// </summary>
+/// <remarks>
+/// A <c>.resw</c> is written by hand and read on every keystroke, inside the process that serves the editor.
+/// Parsing that can be made to take exponential time, or to expand a few hundred bytes into gigabytes, is not
+/// a slow build: it is an editor that stops responding, on input a typo can produce.
+/// </remarks>
+public class MalformedResourceFiles
+{
+    /// <summary>
+    /// How long the parsing of a pathological input is allowed to take.
+    /// </summary>
+    /// <remarks>
+    /// Generous on purpose: the failure being guarded against is measured in minutes, so anything of this
+    /// order says the expression no longer backtracks exponentially, without turning a slow machine into a
+    /// failing build.
+    /// </remarks>
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// An unterminated quoted literal, followed by a run of backslashes.
+    /// </summary>
+    /// <remarks>
+    /// This is the shape that used to take exponential time: every backslash could be read either on its own
+    /// or as the start of an escape, so the parser had to try every way of splitting the run before it could
+    /// conclude that the literal is never closed.
+    /// </remarks>
+    private static string UnterminatedLiteral(int backslashes) =>
+        "\"Hello" + new string('\\', backslashes);
+
+    [Theory]
+    [InlineData(24)]
+    [InlineData(32)]
+    [InlineData(48)]
+    [InlineData(64)]
+    public void AnUnterminatedLiteralDoesNotTakeExponentialTimeToSplit(int backslashes)
+    {
+        var source = UnterminatedLiteral(backslashes);
+
+        var elapsed = Time(() => FormatTag.SplitParameters(source).ToArray());
+
+        Assert.True(elapsed < Budget, $"Splitting took {elapsed}, which suggests it backtracks exponentially.");
+    }
+
+    [Theory]
+    [InlineData(24)]
+    [InlineData(32)]
+    [InlineData(48)]
+    [InlineData(64)]
+    public void AnUnterminatedLiteralDoesNotTakeExponentialTimeToParse(int backslashes)
+    {
+        var resw = ReswTestHelpers.CreateResw(
+            ("Greeting", "Hello", "#Format[" + UnterminatedLiteral(backslashes)));
+
+        var elapsed = Time(() => ReswTestHelpers.GenerateCode(resw));
+
+        Assert.True(elapsed < Budget, $"Generating took {elapsed}, which suggests it backtracks exponentially.");
+    }
+
+    /// <summary>
+    /// A run of quotes inside a format tag that is never closed.
+    /// </summary>
+    [Theory]
+    [InlineData(24)]
+    [InlineData(40)]
+    public void AnUnclosedFormatTagDoesNotTakeExponentialTimeToParse(int quotes)
+    {
+        var resw = ReswTestHelpers.CreateResw(
+            ("Greeting", "Hello", "#Format[" + new string('"', quotes)));
+
+        var elapsed = Time(() => ReswTestHelpers.GenerateCode(resw));
+
+        Assert.True(elapsed < Budget, $"Generating took {elapsed}, which suggests it backtracks exponentially.");
+    }
+
+    /// <summary>
+    /// A resource file that declares a document type is refused.
+    /// </summary>
+    /// <remarks>
+    /// Nested entities are what turn a few hundred bytes into gigabytes of expanded text. A resource file has
+    /// no use for a document type, so the reader refuses one outright rather than trying to bound it.
+    /// </remarks>
+    [Fact]
+    public void AResourceFileThatDeclaresADocumentTypeIsRefused()
+    {
+        var bomb = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <!DOCTYPE root [
+              <!ENTITY a "aaaaaaaaaa">
+              <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+              <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+              <!ENTITY d "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
+              <!ENTITY e "&d;&d;&d;&d;&d;&d;&d;&d;&d;&d;">
+            ]>
+            <root>
+              <data name="Boom"><value>&e;</value></data>
+            </root>
+            """;
+
+        var elapsed = Time(() => Assert.Throws<XmlException>(() => ReswParser.Parse(bomb)));
+
+        Assert.True(elapsed < Budget, $"Refusing the document type took {elapsed}.");
+    }
+
+    /// <summary>
+    /// A resource file the parser cannot read is reported, not thrown out of the generator.
+    /// </summary>
+    [Fact]
+    public void AMalformedResourceFileIsReportedRatherThanFailingTheBuild()
+    {
+        var run = ReswGeneratorHarness.Run(
+        [
+            ReswGeneratorHarness.File("en-US", "<root><data name=\"Truncated\"><value>no closing tags"),
+        ]);
+
+        Assert.Contains("RESWP0014", run.DiagnosticIds);
+    }
+
+    private static TimeSpan Time(Action action)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var timedOut = false;
+
+        try
+        {
+            action();
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // The expression gave up on its own. That is the net under it, not the fix, so it counts as a
+            // failure here: an expression that only finishes because it was cut off is still exponential.
+            timedOut = true;
+        }
+
+        var elapsed = stopwatch.Elapsed;
+
+        Assert.False(timedOut, $"The parsing had to be cut off after {elapsed}.");
+
+        return elapsed;
+    }
+}


### PR DESCRIPTION
Two ways a hand-written `.resw` file can stall the build, both reachable from ordinary mistakes rather than deliberate ones.

Addresses the two highest-severity findings from the recent codebase review.

---

## 1. An unterminated quote hangs the parser

### The input

ReswPlus reads the `#Format` tag out of a resource's comment field. That comment is authored by hand and is parsed **on every keystroke, inside the process that serves the editor**. A comment that is mid-edit — a quote opened and not yet closed — is completely routine:

```xml
<data name="Greeting">
  <value>Hello {0}</value>
  <comment>#Format[String name, "Hi \\\\\\\\...</comment>   <!-- quote never closed -->
</data>
```

### Why it explodes

Three expressions described the inside of a quoted literal as *"an escape, or any character that is not a quote"*:

```
(?:\\.|[^"])*
```

A backslash matches **both** branches: on its own via `[^"]`, or as the opening half of `\\.`. For a run of *n* backslashes there are therefore 2ⁿ ways to read it.

That cost is invisible while the literal is closed — the first reading succeeds and the alternatives are never explored. It only appears when the literal is *not* closed: before the parser can conclude "this literal never ends", it must try **every** reading and see each one fail.

Measured against the previous expressions:

| Backslashes | Time |
| --- | --- |
| 28 | 105 ms |
| 30 | 263 ms |
| 32 | 690 ms |
| 34 | 1.9 s |

Roughly ×2 per additional backslash. Forty-odd is minutes. This is not a slow build; it is an editor that stops responding, with no error to explain why.

### The fix

Two of the three expressions now describe the same text in a form that admits only one reading:

```
[^"\\]*(?:\\.[^"\\]*)*
```

Characters that are neither quote nor backslash, then any number of escapes, each followed by more of the same. A backslash can only ever begin an escape, so there is nothing to backtrack through — matching and failing both take time proportional to the length of the input.

The third, `FormatTag.SplitParameters`, is now **read by hand rather than by expression**. Rewriting its pattern was tried first and was insufficient: at 48 backslashes it still had to be abandoned, because the ambiguity was not only inside the literal but in how the surrounding repetition could be satisfied in several ways. A single left-to-right pass is linear regardless of how malformed the input is, and is easier to reason about than the expression it replaces.

All three also carry a 5-second timeout, so that anything missed surfaces as a reported error rather than a hang.

---

## 2. A resource file that expands into gigabytes

`ReswParser` read the file with `XmlDocument.LoadXml` and default settings, which permit a document type declaration. A document type may define entities in terms of one another:

```xml
<!DOCTYPE root [
  <!ENTITY a "aaaaaaaaaa">
  <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">   <!-- 100 chars -->
  <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">   <!-- 1,000 -->
  ...
]>
```

Each level multiplies the previous by ten, so a few hundred bytes on disk expand into as much text as the author cares to nest — exhausting memory in the editor's process.

The file is now read through an `XmlReader` configured with `DtdProcessing.Prohibit`, and with resolution of anything outside the file disabled. A resource file has no legitimate use for a document type, so it is refused outright rather than bounded.

Malformed XML continues to be reported as `RESWP0014` against the offending file, leaving the rest of the project to generate; this PR adds a test holding that behaviour.

---

## Changes

| File | Change |
| --- | --- |
| `FormatTag.cs` | `RegexNamedParameters` rewritten unambiguously; `SplitParameters` replaced with a linear scanner |
| `ReswClassGenerator.cs` | `_regexStringFormat` rewritten unambiguously |
| `ReswParser.cs` | Reads through `XmlReader` with document types prohibited and external resolution disabled |
| `MalformedResourceFiles.cs` | New tests |

No public API or generated output changes. Behaviour for well-formed input is unchanged.

## Verification

412 tests pass and the full solution builds, both samples included.

The timing tests were validated against the *previous* expressions and fail on them, confirming they detect the regression they describe rather than merely passing. Their budget is deliberately set below the parser timeout, so an expression that completes only because it was cut off also fails them.
